### PR TITLE
fix(query-key): name actual ReturnType in FormatException message

### DIFF
--- a/lib/src/models/query_key.dart
+++ b/lib/src/models/query_key.dart
@@ -29,7 +29,7 @@ class QueryKey<RequestType extends QuerySerializable<ReturnType, ErrorType>, Ret
             try {
               return request.responseHandler(response);
             } catch (e) {
-              throw FormatException('parsing the response of type ${response.runtimeType} to ${ReturnType.runtimeType} failed: ${e.toString()}');
+              throw FormatException('parsing the response of type ${response.runtimeType} to $ReturnType failed: ${e.toString()}');
             }
           });
         } catch (e) {

--- a/test/src/models/query_key_test.dart
+++ b/test/src/models/query_key_test.dart
@@ -207,6 +207,27 @@ void main() {
       );
     });
 
+    test('FormatException message names the actual ReturnType (not the literal "Type")', () async {
+      final user = User(id: 1, name: 'A', email: 'a@b.c');
+      when(mockApiService.getUser(1)).thenAnswer((_) async => user);
+
+      final request = _BadResponseQuery(apiService: mockApiService, localCache: cachedQuery);
+      final query = request.queryKey.query();
+
+      Object? captured;
+      try {
+        await query.fetch();
+      } catch (e) {
+        captured = e;
+      }
+      final stateError = query.state.error ?? captured;
+
+      expect(stateError, isNotNull, reason: 'expected an error to be recorded for the failed responseHandler');
+      final message = stateError.toString();
+      expect(message, contains('to User failed'), reason: 'expected the actual ReturnType name in the FormatException message, got: $message');
+      expect(message, isNot(contains('to Type failed')), reason: 'message must not contain the literal "Type"');
+    });
+
     test('should call onSuccess callback on successful fetch', () async {
       final user = User(id: 123, name: 'John Doe', email: 'john@example.com');
       when(mockApiService.getUser(123)).thenAnswer((_) async => user);
@@ -320,6 +341,29 @@ void main() {
       expect(result, null);
     });
   });
+}
+
+// Helper that always fails inside responseHandler to exercise the FormatException path
+class _BadResponseQuery extends QuerySerializable<User, ApiError> {
+  final MockApiService apiService;
+  final CachedQuery localCache;
+
+  _BadResponseQuery({required this.apiService, required this.localCache});
+
+  @override
+  Map<String, dynamic> toJson() => {'id': 1};
+
+  @override
+  CachedQuery get cache => localCache;
+
+  @override
+  QueryException errorMapper(ApiError error) => QueryException(error.message, error.code);
+
+  @override
+  Future<dynamic> queryFn() async => apiService.getUser(1);
+
+  @override
+  User responseHandler(dynamic response) => throw Exception('responseHandler intentionally failed');
 }
 
 // Helper class for testing error scenarios


### PR DESCRIPTION
## Summary
- `${ReturnType.runtimeType}` interpolated to the literal `Type` because `Type.runtimeType` is itself the `Type` metaclass.
- Use `$ReturnType` so the message names the user-supplied generic argument.

## Test plan
- [x] Added RED test asserting message contains `to User failed` and does not contain `to Type failed`.
- [x] `flutter test` — 85 / 85 pass (was 84).

Closes #4