### PR TITLE
refactor(errors): make OnErrorResults immutable

### DIFF
--- a/lib/src/models/serializable.dart
+++ b/lib/src/models/serializable.dart
@@ -304,8 +304,8 @@ extension InfiniteQuerySerializableExtension<
 }
 
 class OnErrorResults<RequestType, ReturnType> {
-  RequestType request;
-  MutationException error;
-  ReturnType? fallback;
-  OnErrorResults({required this.request, required this.error, this.fallback});
+  final RequestType request;
+  final MutationException error;
+  final ReturnType? fallback;
+  const OnErrorResults({required this.request, required this.error, this.fallback});
 }

--- a/test/src/models/serializable_test.dart
+++ b/test/src/models/serializable_test.dart
@@ -275,6 +275,20 @@ void main() {
       expect(result.error, error);
       expect(result.fallback, null);
     });
+
+    test('OnErrorResults exposes final fields (read-only after construction)', () {
+      final request = CreateUserRequest(name: 'A', email: 'a@b.c');
+      final mutationSerializable = TestMutationSerializable(request: request);
+      final error = MutationException('e', 500);
+      final fallback = User(id: 1, name: 'F', email: 'f@b.c');
+
+      final result = OnErrorResults(request: mutationSerializable, error: error, fallback: fallback);
+
+      // Identity holds — fields are not copied or replaced after construction.
+      expect(identical(result.request, mutationSerializable), isTrue);
+      expect(identical(result.error, error), isTrue);
+      expect(identical(result.fallback, fallback), isTrue);
+    });
   });
 
   group('Serializable Integration Tests', () {


### PR DESCRIPTION
## Summary
- Mark `request`/`error`/`fallback` final; constructor is `const`.
- Audit verified no call site mutates the fields.
- New test asserts field identity after construction (proxy for immutability).

## Test plan
- [x] `flutter test` — 82 / 82 pass.
- [x] `dart analyze lib/src/models/serializable.dart` — clean.

Closes #10