### PR TITLE
fix(query-key,infinite-query-key): invoke updateData function exactly once

### DIFF
--- a/lib/src/models/infinite_query_key.dart
+++ b/lib/src/models/infinite_query_key.dart
@@ -119,15 +119,13 @@ class InfiniteQueryKey<RequestType extends InfiniteQuerySerializable<ReturnType,
   /// Update the infinite query data
   T updateData<T>(T Function(InfiniteQueryData<ReturnType, RequestData>? existingData) updateFunction) {
     if (_getInfiniteQuery == null) {
-      final newData = updateFunction(null);
-      _cache.setQueryData(key: _valueKey, data: newData);
-      return newData;
+      final initial = updateFunction(null);
+      _cache.setQueryData(key: _valueKey, data: initial);
+      return initial;
     }
-
-    final currentData = _getInfiniteQuery!.state.data;
-    final newData = updateFunction(currentData);
-    _cache.updateQuery(key: _valueKey, updateFn: (oldData) => updateFunction(oldData as InfiniteQueryData<ReturnType, RequestData>?));
-    return newData;
+    final next = updateFunction(_getInfiniteQuery!.state.data);
+    _cache.updateQuery(key: _valueKey, updateFn: (_) => next);
+    return next;
   }
 
   /// Invalidate the infinite query

--- a/lib/src/models/query_key.dart
+++ b/lib/src/models/query_key.dart
@@ -78,14 +78,13 @@ class QueryKey<RequestType extends QuerySerializable<ReturnType, ErrorType>, Ret
 
   T updateData<T>(T Function(ReturnType? existingData) updateFunction) {
     if (_getQuery == null) {
-      _cache.setQueryData(key: _valueKey, data: updateFunction(null));
-      return updateFunction(null);
+      final initial = updateFunction(null);
+      _cache.setQueryData(key: _valueKey, data: initial);
+      return initial;
     }
-
-    final currentData = _getQuery!.state.data;
-    final newData = updateFunction(currentData);
-    _cache.updateQuery(key: _valueKey, updateFn: (oldData) => updateFunction(oldData as ReturnType?));
-    return newData;
+    final next = updateFunction(_getQuery!.state.data);
+    _cache.updateQuery(key: _valueKey, updateFn: (_) => next);
+    return next;
   }
 
   void invalidate({bool refetchActive = true, bool refetchInactive = false}) {

--- a/test/src/models/infinite_query_key_test.dart
+++ b/test/src/models/infinite_query_key_test.dart
@@ -351,6 +351,29 @@ void main() {
       expect(result.pages.first.users.first.name, 'Updated John');
     });
 
+    test('updateData invokes the user function exactly once (existing data path)', () async {
+      final pageResponse = PagedResponse(
+        users: [User(id: 1, name: 'John', email: 'john@example.com')],
+        page: 1,
+        totalPages: 1,
+        hasNext: false,
+      );
+      when(mockApiService.getUsersPage(PageArgs(page: 1, limit: 10))).thenAnswer((_) async => pageResponse);
+
+      final request = GetUsersInfiniteQuery(apiService: mockApiService, localCache: cachedQuery);
+      final infiniteQueryKey = InfiniteQueryKey(request);
+      await infiniteQueryKey.query().fetch();
+
+      var calls = 0;
+      final replacement = InfiniteQueryData<PagedResponse, PageArgs>(pages: [pageResponse], args: [PageArgs(page: 1, limit: 10)]);
+      infiniteQueryKey.updateData<InfiniteQueryData<PagedResponse, PageArgs>>((existingData) {
+        calls += 1;
+        return replacement;
+      });
+
+      expect(calls, 1, reason: 'updateFunction must be invoked exactly once per updateData call');
+    });
+
     test('should invalidate query correctly', () async {
       final pageResponse = PagedResponse(
         users: [User(id: 1, name: 'John', email: 'john@example.com')],

--- a/test/src/models/query_key_test.dart
+++ b/test/src/models/query_key_test.dart
@@ -300,6 +300,36 @@ void main() {
       expect(result, newUser);
     });
 
+    test('updateData invokes the user function exactly once (existing data path)', () async {
+      final user = User(id: 1, name: 'A', email: 'a@b.c');
+      when(mockApiService.getUser(1)).thenAnswer((_) async => user);
+
+      final request = GetUserQuery(userId: 1, apiService: mockApiService, localCache: cachedQuery);
+      final queryKey = QueryKey(request);
+      await queryKey.query().fetch();
+
+      var calls = 0;
+      queryKey.updateData<User>((existingData) {
+        calls += 1;
+        return User(id: existingData!.id, name: '${existingData.name}!', email: existingData.email);
+      });
+
+      expect(calls, 1, reason: 'updateFunction must be invoked exactly once per updateData call');
+    });
+
+    test('updateData invokes the user function exactly once (no existing data path)', () async {
+      final request = GetUserQuery(userId: 2, apiService: mockApiService, localCache: cachedQuery);
+      final queryKey = QueryKey(request);
+
+      var calls = 0;
+      queryKey.updateData<User>((existingData) {
+        calls += 1;
+        return User(id: 2, name: 'New', email: 'n@b.c');
+      });
+
+      expect(calls, 1);
+    });
+
     test('should invalidate query correctly', () async {
       final user = User(id: 123, name: 'John Doe', email: 'john@example.com');
       when(mockApiService.getUser(123)).thenAnswer((_) async => user);


### PR DESCRIPTION
## Summary
- Both branches of `QueryKey.updateData` and `InfiniteQueryKey.updateData` invoked the user fn twice. Compute once and reuse.

## Test plan
- [x] RED tests added asserting invocation count == 1 in both paths.
- [x] `flutter test` — 85 / 85 pass.

Closes #19