### PR TITLE
fix(infinite-query-key): propagate getNextArg errors instead of silently terminating pagination

### DIFF
--- a/lib/src/models/infinite_query_key.dart
+++ b/lib/src/models/infinite_query_key.dart
@@ -45,18 +45,21 @@ class InfiniteQueryKey<RequestType extends InfiniteQuerySerializable<ReturnType,
         try {
           return request.getNextArg(data);
         } catch (e) {
-          if (e is ErrorType) {
-            onError?.call(request.errorMapper(e as ErrorType));
-          } else {
-            onError?.call(QueryException('An unhandled exception occurred in getNextArg: ${e.toString()}', 500));
-          }
-          return null;
+          if (e is ErrorType) rethrow;
+          throw QueryException('An unhandled exception occurred in getNextArg: ${e.toString()}', 500);
         }
       },
-      onError: (error) => error is QueryException
-          /// if the error is not handled, it will throw as QueryException with generic message and error contents turned as [String].
-          ? throw error
-          : onError?.call(request.errorMapper(error as ErrorType)),
+      onError: (error) {
+        if (error is QueryException) {
+          onError?.call(error);
+          return;
+        }
+        if (error is ErrorType) {
+          onError?.call(request.errorMapper(error));
+          return;
+        }
+        onError?.call(QueryException('An unhandled exception occurred: ${error.toString()}', 500));
+      },
       onSuccess: onSuccess,
       config: QueryConfig(
         storageSerializer: request.storageSerializer,

--- a/lib/src/models/serializable.dart
+++ b/lib/src/models/serializable.dart
@@ -271,8 +271,15 @@ abstract class InfiniteQuerySerializable<ReturnType, RequestData, ErrorType> {
   /// Takes [RequestData] (typically page number, offset, or cursor) to determine what data to fetch
   Future<ReturnType> queryFn(RequestData requestData);
 
-  /// Determines the argument for the next page based on the current infinite query data
-  /// Return null when there are no more pages to load, or the next [RequestData] argument to fetch the next page
+  /// Determines the argument for the next page based on the current infinite query data.
+  ///
+  /// **Return** the next [RequestData] argument to fetch a further page, or `null` when there
+  /// are no more pages to load.
+  ///
+  /// **Error contract:** if this method throws, the failure is propagated to the underlying
+  /// `InfiniteQuery` and surfaces as an error state (rather than silently terminating pagination).
+  /// Errors of type [ErrorType] flow through [errorMapper]; any other thrown object is wrapped in
+  /// a generic [QueryException] before being delivered to the user-supplied `onError` callback.
   RequestData? getNextArg(InfiniteQueryData<ReturnType, RequestData>? data);
 
   /// Used for persisting the infinite query data to storage, should convert [InfiniteQueryData] to a [Map<String, dynamic>]

--- a/test/src/models/infinite_query_key_test.dart
+++ b/test/src/models/infinite_query_key_test.dart
@@ -135,6 +135,31 @@ class GetUsersInfiniteQuery extends InfiniteQuerySerializable<PagedResponse, Pag
   bool get storeQuery => true;
 }
 
+// Helper that throws inside getNextArg only after the first page has been fetched —
+// exercises the fetch-time error-propagation path (initial construction succeeds).
+class _ThrowingGetNextArgQuery extends InfiniteQuerySerializable<PagedResponse, PageArgs, ApiError> {
+  final CachedQuery localCache;
+  final Object errorToThrow;
+  _ThrowingGetNextArgQuery({required this.localCache, required this.errorToThrow});
+
+  @override
+  String keyGenerator() => 'throwing_get_next_arg';
+  @override
+  QueryException errorMapper(ApiError error) => QueryException('API Error: ${error.message}', error.code);
+  @override
+  PagedResponse responseHandler(dynamic response) => response as PagedResponse;
+  @override
+  CachedQuery get cache => localCache;
+  @override
+  Future<PagedResponse> queryFn(PageArgs arg) async =>
+      PagedResponse(users: [User(id: arg.page, name: 'u${arg.page}', email: 'u@b.c')], page: arg.page, totalPages: 5, hasNext: true);
+  @override
+  PageArgs? getNextArg(InfiniteQueryData<PagedResponse, PageArgs>? data) {
+    if (data == null || data.pages.isEmpty) return PageArgs(page: 1, limit: 10);
+    throw errorToThrow;
+  }
+}
+
 void main() {
   late MockMockApiService mockApiService;
   late CachedQuery cachedQuery;
@@ -372,6 +397,36 @@ void main() {
       });
 
       expect(calls, 1, reason: 'updateFunction must be invoked exactly once per updateData call');
+    });
+
+    test('getNextArg throw of ErrorType propagates to error state (not "no more pages")', () async {
+      final request = _ThrowingGetNextArgQuery(localCache: cachedQuery, errorToThrow: ApiError('boom', 503));
+      final infiniteQueryKey = InfiniteQueryKey(request);
+      final query = infiniteQueryKey.query();
+
+      // First page succeeds.
+      await query.fetch();
+      expect(infiniteQueryKey.isError, isFalse);
+
+      // Subsequent getNextArg throws — must surface as error, not silent end-of-pagination.
+      try {
+        await query.getNextPage();
+      } catch (_) {/* expected to surface */}
+
+      expect(query.state.error, isNotNull, reason: 'A throwing getNextArg must surface as an error state, not as silent end-of-pagination');
+    });
+
+    test('getNextArg throw of unknown error surfaces an error state', () async {
+      final request = _ThrowingGetNextArgQuery(localCache: cachedQuery, errorToThrow: StateError('unexpected'));
+      final infiniteQueryKey = InfiniteQueryKey(request);
+      final query = infiniteQueryKey.query();
+
+      await query.fetch();
+      try {
+        await query.getNextPage();
+      } catch (_) {/* expected */}
+
+      expect(query.state.error, isNotNull);
     });
 
     test('should invalidate query correctly', () async {


### PR DESCRIPTION
## Summary
- Rethrow errors raised inside `request.getNextArg` instead of swallowing and returning null (which cached_query interprets as "no more pages").
- Errors of `ErrorType` rethrow as-is and flow through `errorMapper` in the existing onError plumbing; any other thrown object is wrapped in a generic `QueryException` so the type contract holds.
- Fix a latent bug in the InfiniteQueryKey `onError` closure: throwing a `QueryException` from inside cached_query's controller event handler aborts the handler before it can call `_setState(error: ...)`. Replace the throw with a direct call to the user's onError callback so the state transitions to `InfiniteQueryError` as expected.
- Add dartdoc to `InfiniteQuerySerializable.getNextArg` documenting the error-propagation contract.

## Test plan
- [x] RED tests added for both `ErrorType` and unknown-error throw paths in `getNextArg`.
- [x] `flutter test` — 87 / 87 pass.

Closes #5