### PR TITLE
test(config): cover configureFlutter, createNewInstance, createNewMutationCache

### DIFF
--- a/test/src/config/cached_query_config_test.dart
+++ b/test/src/config/cached_query_config_test.dart
@@ -1,20 +1,62 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:typed_cached_query/src/config/cached_query_config.dart';
 
+class _RecordingObserver extends QueryObserver {
+  int onChangeCount = 0;
+  @override
+  void onChange(dynamic query, dynamic state) {
+    onChangeCount += 1;
+  }
+}
+
 void main() {
-  group('TypedCachedQuery Configuration Tests', () {
-    test('should create TypedCachedQuery configuration class', () {
-      WidgetsFlutterBinding.ensureInitialized();
-      expect(TypedCachedQuery, isNotNull);
-      expect(TypedCachedQuery.configureFlutter, isA<Function>());
+  setUpAll(() {
+    WidgetsFlutterBinding.ensureInitialized();
+  });
+
+  group('TypedCachedQuery.createNewInstance', () {
+    test('returns an instance distinct from the global singleton', () {
+      final isolated = TypedCachedQuery.createNewInstance();
+      expect(identical(isolated, CachedQuery.instance), isFalse);
     });
 
-    test('should allow calling configureFlutter method', () {
-      WidgetsFlutterBinding.ensureInitialized();
-      // Just test that the method exists and can be called
-      // We avoid actually calling it since cached_query only allows one config
-      expect(() => TypedCachedQuery, returnsNormally);
+    test('repeated calls return distinct instances', () {
+      final a = TypedCachedQuery.createNewInstance();
+      final b = TypedCachedQuery.createNewInstance();
+      expect(identical(a, b), isFalse);
+    });
+  });
+
+  group('TypedCachedQuery.createNewMutationCache', () {
+    test('returns an instance distinct from the global mutation cache', () {
+      final isolated = TypedCachedQuery.createNewMutationCache();
+      expect(identical(isolated, MutationCache.instance), isFalse);
+    });
+
+    test('repeated calls return distinct instances', () {
+      final a = TypedCachedQuery.createNewMutationCache();
+      final b = TypedCachedQuery.createNewMutationCache();
+      expect(identical(a, b), isFalse);
+    });
+  });
+
+  group('TypedCachedQuery.configureFlutter', () {
+    // CachedQuery enforces config-set-once per isolate, so all forwarding assertions
+    // run against a single configureFlutter call.
+    test('forwards observers and config to CachedQuery.instance', () {
+      final observer = _RecordingObserver();
+      const customConfig = GlobalQueryConfig(refetchOnResume: false);
+
+      TypedCachedQuery.configureFlutter(
+        neverCheckConnection: true,
+        config: customConfig,
+        observers: [observer],
+      );
+
+      expect(CachedQuery.instance.observers, contains(observer));
+      expect(CachedQuery.instance.defaultConfig.refetchOnResume, isFalse);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Replace stub assertions with behaviour-level tests on `TypedCachedQuery` static helpers.
- New tests verify isolation of `createNewInstance` / `createNewMutationCache` from singletons and that `configureFlutter` forwards observers and config to `CachedQuery.instance`.

## Test plan
- [x] `flutter test` — 90 / 90 pass.

Closes #8