### PR TITLE
feat(mutation-key): make retry backoff configurable

### DIFF
--- a/lib/src/models/mutation_key.dart
+++ b/lib/src/models/mutation_key.dart
@@ -5,6 +5,10 @@ import 'package:typed_cached_query/src/errors/query_exception.dart';
 import 'package:typed_cached_query/src/models/query_key.dart';
 import 'package:typed_cached_query/src/models/serializable.dart';
 
+/// Default linear backoff used when no [backoff] is supplied: 100 ms × attempt.
+/// `attempt` is 1-based — i.e. called with 1 between attempts 1 and 2, 2 between 2 and 3, etc.
+Duration defaultMutationBackoff(int attempt) => Duration(milliseconds: 100 * attempt);
+
 class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnType, ErrorType>, ReturnType, ErrorType> {
   final RequestType request;
   MutationKey(this.request);
@@ -22,6 +26,7 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
     bool Function(ErrorType)? shouldRetry,
     int? timeoutSeconds,
     void Function(RequestType)? onTimeout,
+    Duration Function(int attempt)? backoff,
   }) {
     if ((retryAttempts == null) != (shouldRetry == null)) throw ArgumentError('Either provide both retryAttempts and shouldRetry, or neither.');
 
@@ -31,6 +36,7 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
 
     // Explicitly capture the onTimeout parameter to avoid closure capture issues
     final capturedOnTimeout = onTimeout;
+    final backoffFn = backoff ?? defaultMutationBackoff;
 
     return Mutation<ReturnType, RequestType>(
       key: _valueKey,
@@ -61,7 +67,7 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
             }
             if (shouldRetry == null || attempts >= maxAttempts || !shouldRetry(e as ErrorType)) rethrow;
 
-            await Future<void>.delayed(Duration(milliseconds: 100 * attempts));
+            await Future<void>.delayed(backoffFn(attempts));
             continue;
           }
         }
@@ -104,6 +110,7 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
     bool Function(ErrorType)? shouldRetry,
     int? timeoutSeconds,
     void Function(RequestType)? onTimeout,
+    Duration Function(int attempt)? backoff,
   }) => definition(
     onError: onError,
     onSuccess: onSuccess,
@@ -115,6 +122,7 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
     shouldRetry: shouldRetry,
     timeoutSeconds: timeoutSeconds,
     onTimeout: onTimeout,
+    backoff: backoff,
   ).mutate(request);
 
   bool get isPending => _getMutation != null && _getMutation!.state.isLoading && _getMutation!.state.data == null;

--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -251,4 +251,68 @@ void main() {
       verify(mockApiService.createUser(request)).called(1);
     });
   });
+
+  group('MutationKey Backoff', () {
+    test('uses defaultMutationBackoff when no backoff is provided', () async {
+      final request = CreateUserRequest(name: 'Bo', email: 'bo@example.com');
+      final user = User(id: 1, name: 'Bo', email: 'bo@example.com');
+      var calls = 0;
+      when(mockApiService.createUser(request)).thenAnswer((_) async {
+        calls += 1;
+        if (calls < 3) throw ValidationError('email', 'temporary');
+        return user;
+      });
+
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      final result = await MutationKey(mutation).mutate(retryAttempts: 2, shouldRetry: (_) => true);
+
+      expect(result.data, user);
+      verify(mockApiService.createUser(request)).called(3);
+    });
+
+    test('invokes the supplied backoff function once per retry with 1-based attempt index', () async {
+      final request = CreateUserRequest(name: 'Bo', email: 'bo@example.com');
+      final user = User(id: 1, name: 'Bo', email: 'bo@example.com');
+      var calls = 0;
+      when(mockApiService.createUser(request)).thenAnswer((_) async {
+        calls += 1;
+        if (calls < 3) throw ValidationError('email', 'temporary');
+        return user;
+      });
+
+      final invocations = <int>[];
+      Duration record(int attempt) {
+        invocations.add(attempt);
+        return Duration.zero; // keep test fast
+      }
+
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      await MutationKey(mutation).mutate(retryAttempts: 2, shouldRetry: (_) => true, backoff: record);
+
+      expect(invocations, [1, 2], reason: 'backoff is called once between attempts, with a 1-based attempt index');
+    });
+
+    test('does not invoke backoff when no retry is requested', () async {
+      final request = CreateUserRequest(name: 'Solo', email: 'solo@example.com');
+      final user = User(id: 1, name: 'Solo', email: 'solo@example.com');
+      when(mockApiService.createUser(request)).thenAnswer((_) async => user);
+
+      var invoked = false;
+      Duration record(int _) {
+        invoked = true;
+        return Duration.zero;
+      }
+
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      final result = await MutationKey(mutation).mutate(backoff: record);
+
+      expect(result.data, user);
+      expect(invoked, isFalse);
+    });
+
+    test('defaultMutationBackoff returns 100 ms × attempt', () {
+      expect(defaultMutationBackoff(1), const Duration(milliseconds: 100));
+      expect(defaultMutationBackoff(3), const Duration(milliseconds: 300));
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- New `Duration Function(int attempt)? backoff` parameter on `MutationKey.definition` and `MutationKey.mutate`.
- Default `defaultMutationBackoff` reproduces the prior linear 100 ms × attempt behaviour.
- Attempt index is 1-based; backoff is consulted only on retry transitions.

## Test plan
- [x] Default behaviour preserved (existing retry test still passes).
- [x] Custom backoff invoked once per retry with the expected attempt index.
- [x] Backoff not invoked when no retry happens.
- [x] `defaultMutationBackoff` returns expected durations.
- [x] `flutter test` — 94 / 94 pass.

Closes #14