### PR TITLE
ci: add GitHub Actions workflow + document local setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Analyze & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Resolve dependencies
+        run: dart pub get
+
+      - name: Static analysis
+        run: dart analyze --fatal-infos lib/
+
+      - name: Run tests
+        run: flutter test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Typed Cached Query
 
+[![CI](https://github.com/ChristopherLinnett/typed_cached_query/actions/workflows/ci.yml/badge.svg)](https://github.com/ChristopherLinnett/typed_cached_query/actions/workflows/ci.yml)
+
 A type-safe wrapper around [cached_query_flutter](https://pub.dev/packages/cached_query_flutter) that provides a clean, strongly-typed API for managing queries and mutations in Flutter applications.
 
 This package abstracts away the complexity of cached_query_flutter while providing better type safety, reduced boilerplate, and a more intuitive API for developers.
@@ -206,3 +208,23 @@ void main() {
 This package is a wrapper around [cached_query_flutter](https://pub.dev/packages/cached_query_flutter) and provides a more developer-friendly API while maintaining all the powerful caching and state management features of the underlying library.
 
 For more examples, see the `/example` folder in the repository.
+
+## Development
+
+Local setup for contributors:
+
+```bash
+# Resolve dependencies (use dart pub get rather than flutter pub get)
+dart pub get
+
+# (Re)generate mockito mocks if you change @GenerateMocks declarations
+dart run build_runner build --delete-conflicting-outputs
+
+# Run static analysis on lib/
+dart analyze --fatal-infos lib/
+
+# Run the full test suite
+flutter test
+```
+
+CI runs the same `dart pub get` → `dart analyze --fatal-infos lib/` → `flutter test` pipeline on every push and pull request.

--- a/lib/src/builders/infinite_query_builder.dart
+++ b/lib/src/builders/infinite_query_builder.dart
@@ -52,6 +52,6 @@ class _TypedInfiniteQueryBuilderState<T, A> extends State<TypedInfiniteQueryBuil
 
   @override
   Widget build(BuildContext context) {
-    return widget.builder(context, _currentState, widget.query.getNextPage, widget.query.hasReachedMax());
+    return widget.builder(context, _currentState, widget.query.getNextPage, !widget.query.hasNextPage());
   }
 }

--- a/lib/src/models/infinite_query_key.dart
+++ b/lib/src/models/infinite_query_key.dart
@@ -94,14 +94,11 @@ class InfiniteQueryKey<RequestType extends InfiniteQuerySerializable<ReturnType,
   bool get isError => _getInfiniteQuery != null && _getInfiniteQuery!.state.isError;
   bool get hasReachedMax {
     if (_getInfiniteQuery == null) return false;
-
-    // Use the InfiniteQuery's native hasReachedMax method
     if (_getInfiniteQuery is InfiniteQuery<ReturnType, RequestData>) {
-      return (_getInfiniteQuery as InfiniteQuery<ReturnType, RequestData>).hasReachedMax();
+      return !(_getInfiniteQuery as InfiniteQuery<ReturnType, RequestData>).hasNextPage();
     }
-
-    // Fallback to checking the state
-    return _getInfiniteQuery!.state is InfiniteQuerySuccess && (_getInfiniteQuery!.state as InfiniteQuerySuccess).hasReachedMax;
+    final state = _getInfiniteQuery!.state;
+    return state is InfiniteQuerySuccess<ReturnType, RequestData> && !state.hasNextPage;
   }
 
   QueryException? get error =>


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` running pub get → `dart analyze --fatal-infos lib/` → `flutter test` on every push and PR.
- Replace three deprecated `hasReachedMax()` calls in `lib/` with `!hasNextPage()` / `!state.hasNextPage` to satisfy --fatal-infos. Behaviour preserved.
- Add a Development section to the README and a CI status badge.

## Test plan
- [x] `dart analyze --fatal-infos lib/` — clean.
- [x] `flutter test` — 94 / 94 pass.
- CI status will be visible once this PR is merged and the workflow runs against `main`.

Closes #7