### PR TITLE
test(builders): add widget-layer test coverage

### DIFF
--- a/test/src/builders/infinite_query_builder_test.dart
+++ b/test/src/builders/infinite_query_builder_test.dart
@@ -1,0 +1,104 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:typed_cached_query/src/builders/infinite_query_builder.dart';
+
+InfiniteQuery<String, int> _makeInfinite(CachedQuery cache, String key, {required int maxPage}) {
+  return InfiniteQuery<String, int>(
+    cache: cache,
+    key: key,
+    queryFn: (page) async => 'page-$page',
+    getNextArg: (data) {
+      if (data == null || data.pages.isEmpty) return 1;
+      final next = data.args.last + 1;
+      return next > maxPage ? null : next;
+    },
+    config: const QueryConfig(staleDuration: Duration.zero, ignoreCacheDuration: true),
+  );
+}
+
+Widget _harness(Widget child) => Directionality(textDirection: TextDirection.ltr, child: child);
+
+void main() {
+  late CachedQuery cache;
+
+  setUp(() {
+    cache = CachedQuery.asNewInstance();
+  });
+
+  testWidgets('renders state and rebuilds on stream emission', (tester) async {
+    final query = _makeInfinite(cache, 'iq-render', maxPage: 2);
+
+    await tester.pumpWidget(
+      _harness(
+        TypedInfiniteQueryBuilder<String, int>(
+          query: query,
+          builder: (context, state, fetchNext, hasReachedMax) {
+            final pages = state.data?.pages.join(',') ?? 'idle';
+            return Text(pages);
+          },
+        ),
+      ),
+    );
+    expect(find.text('idle'), findsOneWidget);
+    await tester.pumpAndSettle();
+    expect(find.text('page-1'), findsOneWidget);
+  });
+
+  testWidgets('fetchNextPage callback advances pagination', (tester) async {
+    final query = _makeInfinite(cache, 'iq-paginate', maxPage: 3);
+
+    Future<dynamic> Function()? capturedNext;
+    await tester.pumpWidget(
+      _harness(
+        TypedInfiniteQueryBuilder<String, int>(
+          query: query,
+          builder: (context, state, fetchNext, hasReachedMax) {
+            capturedNext = fetchNext;
+            return Text(state.data?.pages.length.toString() ?? '0');
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('1'), findsOneWidget);
+
+    await capturedNext!();
+    await tester.pumpAndSettle();
+    expect(find.text('2'), findsOneWidget);
+  });
+
+  testWidgets('didUpdateWidget swaps subscription when the query changes', (tester) async {
+    final qa = _makeInfinite(cache, 'iq-A', maxPage: 1);
+    final qb = _makeInfinite(cache, 'iq-B', maxPage: 1);
+
+    Widget under(InfiniteQuery<String, int> q) => _harness(
+      TypedInfiniteQueryBuilder<String, int>(
+        query: q,
+        builder: (context, state, fetchNext, hasReachedMax) => Text(state.data?.pages.firstOrNull ?? '?'),
+      ),
+    );
+
+    await tester.pumpWidget(under(qa));
+    await tester.pumpAndSettle();
+    expect(find.text('page-1'), findsOneWidget);
+
+    await tester.pumpWidget(under(qb));
+    await tester.pumpAndSettle();
+    expect(find.text('page-1'), findsOneWidget);
+  });
+
+  testWidgets('dispose cancels subscription', (tester) async {
+    final query = _makeInfinite(cache, 'iq-dispose', maxPage: 1);
+    await tester.pumpWidget(
+      _harness(
+        TypedInfiniteQueryBuilder<String, int>(
+          query: query,
+          builder: (context, state, fetchNext, hasReachedMax) => const Text('x'),
+        ),
+      ),
+    );
+    await tester.pumpWidget(_harness(const SizedBox.shrink()));
+    await tester.pumpAndSettle();
+  });
+}

--- a/test/src/builders/mutation_builder_test.dart
+++ b/test/src/builders/mutation_builder_test.dart
@@ -1,0 +1,85 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:typed_cached_query/src/builders/mutation_builder.dart';
+
+Mutation<String, int> _makeMutation(MutationCache cache, String key, Future<String> Function(int) fn) {
+  return Mutation<String, int>(
+    cache: cache,
+    key: key,
+    mutationFn: fn,
+  );
+}
+
+Widget _harness(Widget child) => Directionality(textDirection: TextDirection.ltr, child: child);
+
+void main() {
+  late MutationCache cache;
+
+  setUp(() {
+    cache = MutationCache.asNewInstance();
+  });
+
+  testWidgets('renders initial mutation state and exposes the mutate function', (tester) async {
+    final mutation = _makeMutation(cache, 'm-exec', (input) async => 'result-$input');
+
+    Future<MutationState<String?>> Function(int)? capturedMutate;
+    await tester.pumpWidget(
+      _harness(
+        TypedMutationBuilder<String, int>(
+          mutation: mutation,
+          builder: (context, state, mutate) {
+            capturedMutate = mutate;
+            return Text(state.data ?? 'idle');
+          },
+        ),
+      ),
+    );
+    expect(find.text('idle'), findsOneWidget);
+    expect(capturedMutate, isNotNull);
+
+    await capturedMutate!(7);
+    await tester.pumpAndSettle();
+    expect(find.text('result-7'), findsOneWidget);
+  });
+
+  testWidgets('didUpdateWidget swaps subscription when the mutation changes', (tester) async {
+    final m1 = _makeMutation(cache, 'm-1', (i) async => '1-$i');
+    final m2 = _makeMutation(cache, 'm-2', (i) async => '2-$i');
+
+    Widget under(Mutation<String, int> m) => _harness(
+      TypedMutationBuilder<String, int>(
+        mutation: m,
+        builder: (context, state, mutate) => Text(state.data ?? '?'),
+      ),
+    );
+
+    await tester.pumpWidget(under(m1));
+    await m1.mutate(1);
+    await tester.pumpAndSettle();
+    expect(find.text('1-1'), findsOneWidget);
+
+    await tester.pumpWidget(under(m2));
+    await m2.mutate(9);
+    await tester.pumpAndSettle();
+    expect(find.text('2-9'), findsOneWidget);
+  });
+
+  testWidgets('dispose cancels the subscription so post-dispose events do not throw', (tester) async {
+    final mutation = _makeMutation(cache, 'm-dispose', (i) async {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      return 'late-$i';
+    });
+
+    await tester.pumpWidget(
+      _harness(
+        TypedMutationBuilder<String, int>(
+          mutation: mutation,
+          builder: (context, state, mutate) => Text(state.data ?? '?'),
+        ),
+      ),
+    );
+    await tester.pumpWidget(_harness(const SizedBox.shrink()));
+    await tester.pumpAndSettle();
+  });
+}

--- a/test/src/builders/mutation_listener_test.dart
+++ b/test/src/builders/mutation_listener_test.dart
@@ -1,0 +1,126 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:typed_cached_query/src/builders/mutation_listener.dart';
+
+Mutation<String, int> _makeMutation(MutationCache cache, String key, Future<String> Function(int) fn) {
+  return Mutation<String, int>(cache: cache, key: key, mutationFn: fn);
+}
+
+Widget _harness(Widget child) => Directionality(textDirection: TextDirection.ltr, child: child);
+
+void main() {
+  late MutationCache cache;
+  setUp(() => cache = MutationCache.asNewInstance());
+
+  testWidgets('renders the child widget', (tester) async {
+    final mutation = _makeMutation(cache, 'ml-render', (i) async => 'ok-$i');
+    await tester.pumpWidget(
+      _harness(
+        TypedMutationListener<String, int>(
+          mutation: mutation,
+          child: const Text('child'),
+        ),
+      ),
+    );
+    expect(find.text('child'), findsOneWidget);
+  });
+
+  testWidgets('onData fires when mutation state changes', (tester) async {
+    final mutation = _makeMutation(cache, 'ml-data', (i) async => 'ok-$i');
+    var calls = 0;
+    await tester.pumpWidget(
+      _harness(
+        TypedMutationListener<String, int>(
+          mutation: mutation,
+          onData: (_, _) => calls += 1,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    await mutation.mutate(1);
+    await tester.pumpAndSettle();
+    expect(calls, greaterThanOrEqualTo(1));
+  });
+
+  testWidgets('onSuccess fires after a successful mutation', (tester) async {
+    final mutation = _makeMutation(cache, 'ml-success', (i) async => 'ok-$i');
+    var successes = 0;
+    await tester.pumpWidget(
+      _harness(
+        TypedMutationListener<String, int>(
+          mutation: mutation,
+          onSuccess: (_, _) => successes += 1,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    await mutation.mutate(1);
+    await tester.pumpAndSettle();
+    expect(successes, greaterThanOrEqualTo(1));
+  });
+
+  testWidgets('onError fires after a failing mutation', (tester) async {
+    final mutation = _makeMutation(cache, 'ml-error', (i) async => throw StateError('nope'));
+    var errors = 0;
+    await tester.pumpWidget(
+      _harness(
+        TypedMutationListener<String, int>(
+          mutation: mutation,
+          onError: (_, _) => errors += 1,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    try {
+      await mutation.mutate(1);
+    } catch (_) {/* expected */}
+    await tester.pumpAndSettle();
+    expect(errors, greaterThanOrEqualTo(1));
+  });
+
+  testWidgets('didUpdateWidget swaps subscription', (tester) async {
+    final ma = _makeMutation(cache, 'ml-A', (i) async => 'a-$i');
+    final mb = _makeMutation(cache, 'ml-B', (i) async => 'b-$i');
+
+    var dataA = 0;
+    var dataB = 0;
+    Widget under(Mutation<String, int> m, void Function(BuildContext, MutationState<String>) onData) => _harness(
+      TypedMutationListener<String, int>(
+        mutation: m,
+        onData: onData,
+        child: const SizedBox.shrink(),
+      ),
+    );
+
+    await tester.pumpWidget(under(ma, (_, _) => dataA += 1));
+    await ma.mutate(1);
+    await tester.pumpAndSettle();
+    final dataABeforeSwap = dataA;
+
+    await tester.pumpWidget(under(mb, (_, _) => dataB += 1));
+    await mb.mutate(2);
+    await tester.pumpAndSettle();
+
+    expect(dataA, dataABeforeSwap, reason: 'after swap, the old subscription must not deliver events');
+    expect(dataB, greaterThanOrEqualTo(1));
+  });
+
+  testWidgets('dispose cancels the subscription', (tester) async {
+    final mutation = _makeMutation(cache, 'ml-dispose', (i) async {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      return 'late-$i';
+    });
+    await tester.pumpWidget(
+      _harness(
+        TypedMutationListener<String, int>(
+          mutation: mutation,
+          onData: (_, _) {},
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    await tester.pumpWidget(_harness(const SizedBox.shrink()));
+    await tester.pumpAndSettle();
+  });
+}

--- a/test/src/builders/query_builder_test.dart
+++ b/test/src/builders/query_builder_test.dart
@@ -1,0 +1,86 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:typed_cached_query/src/builders/query_builder.dart';
+
+Query<String> _makeQuery(CachedQuery cache, String key, Future<String> Function() queryFn) {
+  return Query<String>(
+    cache: cache,
+    key: key,
+    queryFn: queryFn,
+    config: const QueryConfig(staleDuration: Duration.zero, ignoreCacheDuration: true),
+  );
+}
+
+Widget _harness(Widget child) => Directionality(textDirection: TextDirection.ltr, child: child);
+
+void main() {
+  late CachedQuery cache;
+
+  setUp(() {
+    cache = CachedQuery.asNewInstance();
+  });
+
+  testWidgets('renders the initial query state and rebuilds on stream emission', (tester) async {
+    final completer = await Future.value('first');
+    final query = _makeQuery(cache, 'q-emit', () async => completer);
+
+    var lastSeen = '';
+    await tester.pumpWidget(
+      _harness(
+        TypedQueryBuilder<String>(
+          query: query,
+          builder: (context, state) {
+            lastSeen = state.data ?? '';
+            return Text(state.data ?? 'idle');
+          },
+        ),
+      ),
+    );
+    expect(find.text('idle'), findsOneWidget);
+
+    await tester.pumpAndSettle();
+    expect(lastSeen, 'first');
+    expect(find.text('first'), findsOneWidget);
+  });
+
+  testWidgets('didUpdateWidget cancels old subscription and subscribes to the new query', (tester) async {
+    final queryA = _makeQuery(cache, 'q-A', () async => 'A');
+    final queryB = _makeQuery(cache, 'q-B', () async => 'B');
+
+    Widget under(Query<String> q) => _harness(
+      TypedQueryBuilder<String>(
+        query: q,
+        builder: (context, state) => Text(state.data ?? '?'),
+      ),
+    );
+
+    await tester.pumpWidget(under(queryA));
+    await tester.pumpAndSettle();
+    expect(find.text('A'), findsOneWidget);
+
+    await tester.pumpWidget(under(queryB));
+    await tester.pumpAndSettle();
+    expect(find.text('B'), findsOneWidget);
+  });
+
+  testWidgets('dispose cancels the subscription so post-dispose stream events do not throw', (tester) async {
+    final query = _makeQuery(cache, 'q-dispose', () async {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      return 'late';
+    });
+
+    await tester.pumpWidget(
+      _harness(
+        TypedQueryBuilder<String>(
+          query: query,
+          builder: (context, state) => Text(state.data ?? '?'),
+        ),
+      ),
+    );
+    // Replace with an empty widget — disposes the State.
+    await tester.pumpWidget(_harness(const SizedBox.shrink()));
+    // Allow the queryFn future to complete; if dispose forgot to cancel, the late setState would throw.
+    await tester.pumpAndSettle();
+  });
+}

--- a/test/src/builders/query_listener_test.dart
+++ b/test/src/builders/query_listener_test.dart
@@ -1,0 +1,125 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:typed_cached_query/src/builders/query_listener.dart';
+
+Query<String> _makeQuery(CachedQuery cache, String key, Future<String> Function() queryFn) {
+  return Query<String>(
+    cache: cache,
+    key: key,
+    queryFn: queryFn,
+    config: const QueryConfig(staleDuration: Duration.zero, ignoreCacheDuration: true),
+  );
+}
+
+Widget _harness(Widget child) => Directionality(textDirection: TextDirection.ltr, child: child);
+
+void main() {
+  late CachedQuery cache;
+  setUp(() => cache = CachedQuery.asNewInstance());
+
+  testWidgets('renders the child widget', (tester) async {
+    final query = _makeQuery(cache, 'ql-render', () async => 'ok');
+    await tester.pumpWidget(
+      _harness(
+        TypedQueryListener<String>(
+          query: query,
+          child: const Text('child'),
+        ),
+      ),
+    );
+    expect(find.text('child'), findsOneWidget);
+  });
+
+  testWidgets('onChange/onSuccess/onLoading fire at least once during a successful fetch', (tester) async {
+    // Strict transition-count semantics are exercised by the regression tests in #20 / #3
+    // alongside the corresponding listener fixes. Here we assert the wiring is alive.
+    final query = _makeQuery(cache, 'ql-change', () async => 'value');
+    var changes = 0;
+    var successes = 0;
+    var loadings = 0;
+
+    await tester.pumpWidget(
+      _harness(
+        TypedQueryListener<String>(
+          query: query,
+          onChange: (_, _) => changes += 1,
+          onSuccess: (_, _) => successes += 1,
+          onLoading: (_, _) => loadings += 1,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(changes, greaterThanOrEqualTo(1));
+    expect(successes, greaterThanOrEqualTo(1));
+    expect(loadings, greaterThanOrEqualTo(1));
+  });
+
+  testWidgets('onError fires when the query function throws', (tester) async {
+    final query = _makeQuery(cache, 'ql-error', () async => throw StateError('nope'));
+    var errors = 0;
+
+    await tester.pumpWidget(
+      _harness(
+        TypedQueryListener<String>(
+          query: query,
+          onError: (_, _) => errors += 1,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(errors, greaterThanOrEqualTo(1));
+  });
+
+  testWidgets('didUpdateWidget swaps subscription', (tester) async {
+    final qa = _makeQuery(cache, 'ql-A', () async => 'a');
+    final qb = _makeQuery(cache, 'ql-B', () async => 'b');
+
+    var changesA = 0;
+    var changesB = 0;
+    Widget under(Query<String> q, void Function(BuildContext, QueryStatus<String>) onChange) => _harness(
+      TypedQueryListener<String>(
+        query: q,
+        onChange: onChange,
+        child: const SizedBox.shrink(),
+      ),
+    );
+
+    await tester.pumpWidget(under(qa, (_, __) => changesA += 1));
+    await qa.fetch();
+    await tester.pumpAndSettle();
+    final changesABeforeSwap = changesA;
+
+    await tester.pumpWidget(under(qb, (_, __) => changesB += 1));
+    await qb.fetch();
+    await tester.pumpAndSettle();
+
+    expect(changesA, changesABeforeSwap, reason: 'after swap, the old subscription must not deliver events');
+    expect(changesB, greaterThanOrEqualTo(1));
+  });
+
+  testWidgets('dispose cancels the subscription', (tester) async {
+    final query = _makeQuery(cache, 'ql-dispose', () async {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      return 'late';
+    });
+
+    var changes = 0;
+    await tester.pumpWidget(
+      _harness(
+        TypedQueryListener<String>(
+          query: query,
+          onChange: (_, __) => changes += 1,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    await tester.pumpWidget(_harness(const SizedBox.shrink()));
+    await tester.pumpAndSettle();
+    // No expectations on `changes` — the assertion is that pumpAndSettle does not throw.
+  });
+}


### PR DESCRIPTION
## Summary
- 5 new test files under `test/src/builders/` (one per widget) covering initial render, stream emission, `didUpdateWidget` swap, and `dispose` lifecycle.
- Listener tests assert each callback fires at least once on the relevant transition; strict transition-count assertions move to #20 and #3 alongside the listener fixes.

## Test plan
- [x] `flutter test` — 115 / 115 pass (was 94, +21 widget tests).

Closes #21