### PR TITLE
fix(query-listener): make onRefetching reachable

### DIFF
--- a/lib/src/builders/query_listener.dart
+++ b/lib/src/builders/query_listener.dart
@@ -20,10 +20,10 @@ class TypedQueryListener<T> extends StatefulWidget {
   /// Called when the query loads successfully.
   final void Function(BuildContext context, QueryStatus<T> state)? onSuccess;
 
-  /// Called when the query starts loading.
+  /// Called when the query starts loading from a non-loading, no-data state (cold start).
   final void Function(BuildContext context, QueryStatus<T> state)? onLoading;
 
-    /// Called when the query starts loading.
+  /// Called when the query starts a refetch — i.e. transitions into loading while data is already present.
   final void Function(BuildContext context, QueryStatus<T> state)? onRefetching;
 
   /// Creates a [TypedQueryListener].
@@ -75,8 +75,12 @@ class _TypedQueryListenerState<T> extends State<TypedQueryListener<T>> {
 
     if (!previous.isError && current.isError && widget.onError != null) return widget.onError!(context, current);
     if (!previous.isSuccess && current.isSuccess && widget.onSuccess != null) return widget.onSuccess!(context, current);
+    // Refetch must be checked before onLoading: a refetch satisfies the !previous.isLoading && current.isLoading
+    // predicate, so without this earlier branch onRefetching would be unreachable.
+    if (previous.data != null && !previous.isLoading && current.isLoading && widget.onRefetching != null) {
+      return widget.onRefetching!(context, current);
+    }
     if (!previous.isLoading && current.isLoading && widget.onLoading != null) return widget.onLoading!(context, current);
-    if (previous.data != null && current.isLoading && widget.onRefetching != null) return widget.onRefetching!(context, current);
   }
 
   @override

--- a/test/src/builders/query_listener_test.dart
+++ b/test/src/builders/query_listener_test.dart
@@ -75,6 +75,36 @@ void main() {
     expect(errors, greaterThanOrEqualTo(1));
   });
 
+  testWidgets('onRefetching fires when refetching a query that already has data', (tester) async {
+    final query = _makeQuery(cache, 'ql-refetch', () async => 'value');
+
+    var loadings = 0;
+    var refetchings = 0;
+
+    await tester.pumpWidget(
+      _harness(
+        TypedQueryListener<String>(
+          query: query,
+          onLoading: (_, _) => loadings += 1,
+          onRefetching: (_, _) => refetchings += 1,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    // Cold start: stream auto-fetches via onListen.
+    await tester.pumpAndSettle();
+    expect(loadings, greaterThanOrEqualTo(1), reason: 'cold-start fetch must fire onLoading');
+    expect(refetchings, 0, reason: 'onRefetching must not fire on the cold start when there is no prior data');
+
+    // Refetch: data is populated, so the listener should classify the next loading transition as refetching.
+    final loadingsBeforeRefetch = loadings;
+    await query.refetch();
+    await tester.pumpAndSettle();
+
+    expect(refetchings, greaterThanOrEqualTo(1), reason: 'a refetch with data present must fire onRefetching');
+    expect(loadings, loadingsBeforeRefetch, reason: 'onLoading must not fire on a refetch when data is already present');
+  });
+
   testWidgets('didUpdateWidget swaps subscription', (tester) async {
     final qa = _makeQuery(cache, 'ql-A', () async => 'a');
     final qb = _makeQuery(cache, 'ql-B', () async => 'b');


### PR DESCRIPTION
## Summary
- Reorder `_handleStateChange` so the refetch transition (data present + transitioning into loading) is detected before the cold-start `onLoading` branch.
- Fix the duplicated docstring on the `onRefetching` field.

## Test plan
- [x] RED test added asserting `onRefetching` fires on refetch and `onLoading` does not.
- [x] `flutter test` — 116 / 116 pass.
- [x] `dart analyze --fatal-infos lib/` — clean.

Closes #20