### PR TITLE
fix(mutation-listener): fire callbacks on state transitions

### DIFF
--- a/lib/src/builders/mutation_listener.dart
+++ b/lib/src/builders/mutation_listener.dart
@@ -70,11 +70,14 @@ class _TypedMutationListenerState<T, R> extends State<TypedMutationListener<T, R
   void _handleStateChange(MutationState<T> previous, MutationState<T> current) {
     widget.onData?.call(context, current);
 
-    if (current.isError && widget.onError != null) {
+    // Transition-only semantics: only fire on the leading edge of a state change.
+    // Without these guards, every stream emission while state remains in a bucket would re-fire
+    // the corresponding callback (e.g. a BehaviorSubject replay on subscribe).
+    if (!previous.isError && current.isError && widget.onError != null) {
       widget.onError!(context, current);
-    } else if (current.isSuccess && widget.onSuccess != null) {
+    } else if (!previous.isSuccess && current.isSuccess && widget.onSuccess != null) {
       widget.onSuccess!(context, current);
-    } else if (current.isLoading && widget.onLoading != null) {
+    } else if (!previous.isLoading && current.isLoading && widget.onLoading != null) {
       widget.onLoading!(context, current);
     }
   }

--- a/test/src/builders/mutation_listener_test.dart
+++ b/test/src/builders/mutation_listener_test.dart
@@ -43,7 +43,7 @@ void main() {
     expect(calls, greaterThanOrEqualTo(1));
   });
 
-  testWidgets('onSuccess fires after a successful mutation', (tester) async {
+  testWidgets('onSuccess fires exactly once per success transition (not on every emission while in success)', (tester) async {
     final mutation = _makeMutation(cache, 'ml-success', (i) async => 'ok-$i');
     var successes = 0;
     await tester.pumpWidget(
@@ -57,7 +57,39 @@ void main() {
     );
     await mutation.mutate(1);
     await tester.pumpAndSettle();
-    expect(successes, greaterThanOrEqualTo(1));
+    final afterFirstMutate = successes;
+    expect(afterFirstMutate, 1, reason: 'one mutate cycle must produce exactly one success transition');
+
+    // Force an additional pump cycle without producing a new success transition.
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(successes, afterFirstMutate, reason: 'no callback should fire while the state remains in success without a transition');
+
+    // Second mutate produces a second success transition.
+    await mutation.mutate(2);
+    await tester.pumpAndSettle();
+    expect(successes, 2, reason: 'a second mutate cycle adds exactly one further success transition');
+  });
+
+  testWidgets('onSuccess does not fire on a stream replay of the same success state (didUpdateWidget swap to same mutation result)', (tester) async {
+    final mutation = _makeMutation(cache, 'ml-replay', (i) async => 'ok-$i');
+    await mutation.mutate(1);
+    // Wait for completion before listener attaches — listener attaches AFTER state is success.
+
+    var successes = 0;
+    await tester.pumpWidget(
+      _harness(
+        TypedMutationListener<String, int>(
+          mutation: mutation,
+          onSuccess: (_, _) => successes += 1,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // BehaviorSubject replays the current (success) state on subscribe. _previousState was already
+    // set to mutation.state (success) before listen, so handle(success, success) is not a transition.
+    expect(successes, 0, reason: 'replayed success state with no actual transition must not fire onSuccess');
   });
 
   testWidgets('onError fires after a failing mutation', (tester) async {


### PR DESCRIPTION
## Summary
- Add transition guards (`!previous.isError && current.isError`, `!previous.isSuccess && current.isSuccess`, `!previous.isLoading && current.isLoading`) to `TypedMutationListener._handleStateChange`. Mirrors `TypedQueryListener`.
- Without the guards, every stream emission within a bucket re-fired the callback — most visibly the BehaviorSubject's replay of the current success state on subscribe.

## Test plan
- [x] RED tests added asserting:
  - exactly one `onSuccess` per mutate cycle, plus a stable count after additional pumps without transitions.
  - subscribing to a mutation that has already settled in success does not fire `onSuccess` (no transition occurred).
- [x] `flutter test` — 117 / 117 pass.
- [x] `dart analyze --fatal-infos lib/` — clean.

Closes #3