### PR TITLE
refactor(builders): extract shared StreamBackedState mixin

### DIFF
--- a/lib/src/builders/infinite_query_builder.dart
+++ b/lib/src/builders/infinite_query_builder.dart
@@ -1,6 +1,6 @@
-import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:typed_cached_query/src/builders/stream_backed_state.dart';
 
 /// A [TypedInfiniteQueryBuilder] widget that builds its child based on the state of an [InfiniteQuery].
 /// This builder only accepts infinite queries created from [InfiniteQueryKey.query()].
@@ -24,34 +24,21 @@ class TypedInfiniteQueryBuilder<T, A> extends StatefulWidget {
   State<TypedInfiniteQueryBuilder<T, A>> createState() => _TypedInfiniteQueryBuilderState<T, A>();
 }
 
-class _TypedInfiniteQueryBuilderState<T, A> extends State<TypedInfiniteQueryBuilder<T, A>> {
-  late InfiniteQueryStatus<T, A> _currentState;
-  late StreamSubscription<InfiniteQueryStatus<T, A>> _subscription;
+class _TypedInfiniteQueryBuilderState<T, A> extends State<TypedInfiniteQueryBuilder<T, A>>
+    with StreamBackedState<InfiniteQueryStatus<T, A>, TypedInfiniteQueryBuilder<T, A>> {
+  @override
+  Stream<InfiniteQueryStatus<T, A>> streamFor(TypedInfiniteQueryBuilder<T, A> widget) => widget.query.stream;
 
   @override
-  void initState() {
-    super.initState();
-    _currentState = widget.query.state;
-    _subscription = widget.query.stream.listen((state) => mounted ? setState(() => _currentState = state) : null);
-  }
+  InfiniteQueryStatus<T, A> initialStateFor(TypedInfiniteQueryBuilder<T, A> widget) => widget.query.state;
 
   @override
-  void didUpdateWidget(TypedInfiniteQueryBuilder<T, A> oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.query == oldWidget.query) return;
-    _subscription.cancel();
-    _currentState = widget.query.state;
-    _subscription = widget.query.stream.listen((state) => mounted ? setState(() => _currentState = state) : null);
-  }
-
-  @override
-  void dispose() {
-    _subscription.cancel();
-    super.dispose();
+  void onState(InfiniteQueryStatus<T, A> previous, InfiniteQueryStatus<T, A> current) {
+    setState(() {});
   }
 
   @override
   Widget build(BuildContext context) {
-    return widget.builder(context, _currentState, widget.query.getNextPage, !widget.query.hasNextPage());
+    return widget.builder(context, currentState, widget.query.getNextPage, !widget.query.hasNextPage());
   }
 }

--- a/lib/src/builders/mutation_builder.dart
+++ b/lib/src/builders/mutation_builder.dart
@@ -1,6 +1,6 @@
-import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:typed_cached_query/src/builders/stream_backed_state.dart';
 
 /// A [TypedMutationBuilder] widget that builds its child based on the state of a [Mutation].
 /// This builder only accepts mutations created from [MutationKey.definition()].
@@ -18,34 +18,19 @@ class TypedMutationBuilder<T, R> extends StatefulWidget {
   State<TypedMutationBuilder<T, R>> createState() => _TypedMutationBuilderState<T, R>();
 }
 
-class _TypedMutationBuilderState<T, R> extends State<TypedMutationBuilder<T, R>> {
-  late MutationState<T> _currentState;
-  late StreamSubscription<MutationState<T>> _subscription;
+class _TypedMutationBuilderState<T, R> extends State<TypedMutationBuilder<T, R>>
+    with StreamBackedState<MutationState<T>, TypedMutationBuilder<T, R>> {
+  @override
+  Stream<MutationState<T>> streamFor(TypedMutationBuilder<T, R> widget) => widget.mutation.stream;
 
   @override
-  void initState() {
-    super.initState();
-    _currentState = widget.mutation.state;
-    _subscription = widget.mutation.stream.listen((state) => mounted ? setState(() => _currentState = state) : null);
+  MutationState<T> initialStateFor(TypedMutationBuilder<T, R> widget) => widget.mutation.state;
+
+  @override
+  void onState(MutationState<T> previous, MutationState<T> current) {
+    setState(() {});
   }
 
   @override
-  void didUpdateWidget(TypedMutationBuilder<T, R> oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.mutation == oldWidget.mutation) return;
-    _subscription.cancel();
-    _currentState = widget.mutation.state;
-    _subscription = widget.mutation.stream.listen((state) => mounted ? setState(() => _currentState = state) : null);
-  }
-
-  @override
-  void dispose() {
-    _subscription.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return widget.builder(context, _currentState, widget.mutation.mutate);
-  }
+  Widget build(BuildContext context) => widget.builder(context, currentState, widget.mutation.mutate);
 }

--- a/lib/src/builders/mutation_listener.dart
+++ b/lib/src/builders/mutation_listener.dart
@@ -1,6 +1,6 @@
-import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:typed_cached_query/src/builders/stream_backed_state.dart';
 
 /// A [TypedMutationListener] widget that listens to mutation state changes and calls callbacks.
 /// This listener only accepts mutations created from [MutationKey.definition()].
@@ -24,55 +24,33 @@ class TypedMutationListener<T, R> extends StatefulWidget {
   final void Function(BuildContext context, MutationState<T> state)? onLoading;
 
   /// Creates a [TypedMutationListener].
-  const TypedMutationListener({super.key, required this.mutation, required this.child, this.onData, this.onError, this.onSuccess, this.onLoading});
+  const TypedMutationListener({
+    super.key,
+    required this.mutation,
+    required this.child,
+    this.onData,
+    this.onError,
+    this.onSuccess,
+    this.onLoading,
+  });
 
   @override
   State<TypedMutationListener<T, R>> createState() => _TypedMutationListenerState<T, R>();
 }
 
-class _TypedMutationListenerState<T, R> extends State<TypedMutationListener<T, R>> {
-  late MutationState<T> _previousState;
-  late StreamSubscription<MutationState<T>> _subscription;
+class _TypedMutationListenerState<T, R> extends State<TypedMutationListener<T, R>>
+    with StreamBackedState<MutationState<T>, TypedMutationListener<T, R>> {
+  @override
+  Stream<MutationState<T>> streamFor(TypedMutationListener<T, R> widget) => widget.mutation.stream;
 
   @override
-  void initState() {
-    super.initState();
-    _previousState = widget.mutation.state;
-    _subscription = widget.mutation.stream.listen((state) {
-      if (mounted) {
-        _handleStateChange(_previousState, state);
-        _previousState = state;
-      }
-    });
-  }
+  MutationState<T> initialStateFor(TypedMutationListener<T, R> widget) => widget.mutation.state;
 
   @override
-  void didUpdateWidget(TypedMutationListener<T, R> oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.mutation != oldWidget.mutation) {
-      _subscription.cancel();
-      _previousState = widget.mutation.state;
-      _subscription = widget.mutation.stream.listen((state) {
-        if (mounted) {
-          _handleStateChange(_previousState, state);
-          _previousState = state;
-        }
-      });
-    }
-  }
-
-  @override
-  void dispose() {
-    _subscription.cancel();
-    super.dispose();
-  }
-
-  void _handleStateChange(MutationState<T> previous, MutationState<T> current) {
+  void onState(MutationState<T> previous, MutationState<T> current) {
     widget.onData?.call(context, current);
 
     // Transition-only semantics: only fire on the leading edge of a state change.
-    // Without these guards, every stream emission while state remains in a bucket would re-fire
-    // the corresponding callback (e.g. a BehaviorSubject replay on subscribe).
     if (!previous.isError && current.isError && widget.onError != null) {
       widget.onError!(context, current);
     } else if (!previous.isSuccess && current.isSuccess && widget.onSuccess != null) {
@@ -83,7 +61,5 @@ class _TypedMutationListenerState<T, R> extends State<TypedMutationListener<T, R
   }
 
   @override
-  Widget build(BuildContext context) {
-    return widget.child;
-  }
+  Widget build(BuildContext context) => widget.child;
 }

--- a/lib/src/builders/query_builder.dart
+++ b/lib/src/builders/query_builder.dart
@@ -1,6 +1,6 @@
-import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:typed_cached_query/src/builders/stream_backed_state.dart';
 
 /// A [TypedQueryBuilder] widget that builds its child based on the state of a [Query].
 /// This builder only accepts queries created from [QueryKey.query()].
@@ -18,47 +18,19 @@ class TypedQueryBuilder<T> extends StatefulWidget {
   State<TypedQueryBuilder<T>> createState() => _TypedQueryBuilderState<T>();
 }
 
-class _TypedQueryBuilderState<T> extends State<TypedQueryBuilder<T>> {
-  late QueryStatus<T> _currentState;
-  late StreamSubscription<QueryStatus<T>> _subscription;
+class _TypedQueryBuilderState<T> extends State<TypedQueryBuilder<T>>
+    with StreamBackedState<QueryStatus<T>, TypedQueryBuilder<T>> {
+  @override
+  Stream<QueryStatus<T>> streamFor(TypedQueryBuilder<T> widget) => widget.query.stream;
 
   @override
-  void initState() {
-    super.initState();
-    _currentState = widget.query.state;
-    _subscription = widget.query.stream.listen((state) {
-      if (mounted) {
-        setState(() {
-          _currentState = state;
-        });
-      }
-    });
+  QueryStatus<T> initialStateFor(TypedQueryBuilder<T> widget) => widget.query.state;
+
+  @override
+  void onState(QueryStatus<T> previous, QueryStatus<T> current) {
+    setState(() {});
   }
 
   @override
-  void didUpdateWidget(TypedQueryBuilder<T> oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.query != oldWidget.query) {
-      _subscription.cancel();
-      _currentState = widget.query.state;
-      _subscription = widget.query.stream.listen((state) {
-        if (mounted) {
-          setState(() {
-            _currentState = state;
-          });
-        }
-      });
-    }
-  }
-
-  @override
-  void dispose() {
-    _subscription.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return widget.builder(context, _currentState);
-  }
+  Widget build(BuildContext context) => widget.builder(context, currentState);
 }

--- a/lib/src/builders/query_listener.dart
+++ b/lib/src/builders/query_listener.dart
@@ -1,6 +1,6 @@
-import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:typed_cached_query/src/builders/stream_backed_state.dart';
 
 /// A [TypedQueryListener] widget that listens to query state changes and calls callbacks.
 /// This listener only accepts queries created from [QueryKey.query()].
@@ -27,50 +27,31 @@ class TypedQueryListener<T> extends StatefulWidget {
   final void Function(BuildContext context, QueryStatus<T> state)? onRefetching;
 
   /// Creates a [TypedQueryListener].
-  const TypedQueryListener({super.key, required this.query, required this.child, this.onChange, this.onError, this.onSuccess, this.onLoading, this.onRefetching});
+  const TypedQueryListener({
+    super.key,
+    required this.query,
+    required this.child,
+    this.onChange,
+    this.onError,
+    this.onSuccess,
+    this.onLoading,
+    this.onRefetching,
+  });
 
   @override
   State<TypedQueryListener<T>> createState() => _TypedQueryListenerState<T>();
 }
 
-class _TypedQueryListenerState<T> extends State<TypedQueryListener<T>> {
-  late QueryStatus<T> _previousState;
-  late StreamSubscription<QueryStatus<T>> _subscription;
+class _TypedQueryListenerState<T> extends State<TypedQueryListener<T>>
+    with StreamBackedState<QueryStatus<T>, TypedQueryListener<T>> {
+  @override
+  Stream<QueryStatus<T>> streamFor(TypedQueryListener<T> widget) => widget.query.stream;
 
   @override
-  void initState() {
-    super.initState();
-    _previousState = widget.query.state;
-    _subscription = widget.query.stream.listen((state) {
-      if (mounted) {
-        _handleStateChange(_previousState, state);
-        _previousState = state;
-      }
-    });
-  }
+  QueryStatus<T> initialStateFor(TypedQueryListener<T> widget) => widget.query.state;
 
   @override
-  void didUpdateWidget(TypedQueryListener<T> oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.query != oldWidget.query) {
-      _subscription.cancel();
-      _previousState = widget.query.state;
-      _subscription = widget.query.stream.listen((state) {
-        if (mounted) {
-          _handleStateChange(_previousState, state);
-          _previousState = state;
-        }
-      });
-    }
-  }
-
-  @override
-  void dispose() {
-    _subscription.cancel();
-    super.dispose();
-  }
-
-  void _handleStateChange(QueryStatus<T> previous, QueryStatus<T> current) {
+  void onState(QueryStatus<T> previous, QueryStatus<T> current) {
     widget.onChange?.call(context, current);
 
     if (!previous.isError && current.isError && widget.onError != null) return widget.onError!(context, current);
@@ -84,7 +65,5 @@ class _TypedQueryListenerState<T> extends State<TypedQueryListener<T>> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    return widget.child;
-  }
+  Widget build(BuildContext context) => widget.child;
 }

--- a/lib/src/builders/stream_backed_state.dart
+++ b/lib/src/builders/stream_backed_state.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+import 'package:flutter/widgets.dart';
+
+/// Internal mixin that owns the subscription lifecycle for State classes that listen to a stream
+/// produced by a property of their widget.
+///
+/// Subclasses provide [streamFor], [initialStateFor], and [onState], and the mixin handles:
+/// - subscribing in [initState]
+/// - cancelling and resubscribing in [didUpdateWidget] when the stream identity changes
+/// - cancelling in [dispose]
+/// - guarding stream events behind [State.mounted] before propagating to [onState]
+///
+/// [onState] receives the previous and the new state; [currentState] always returns the latest.
+mixin StreamBackedState<S, W extends StatefulWidget> on State<W> {
+  late S _state;
+  late StreamSubscription<S> _subscription;
+
+  /// Returns the stream to listen to for the given widget instance.
+  Stream<S> streamFor(W widget);
+
+  /// Returns the state to seed [currentState] with on (re-)subscribe — typically the stream's
+  /// current value.
+  S initialStateFor(W widget);
+
+  /// Called once per stream event after [currentState] has been updated to [current].
+  void onState(S previous, S current);
+
+  /// The latest state delivered by the stream (or seeded by [initialStateFor]).
+  S get currentState => _state;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe();
+  }
+
+  @override
+  void didUpdateWidget(covariant W oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (streamFor(widget) != streamFor(oldWidget)) {
+      _subscription.cancel();
+      _subscribe();
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+
+  void _subscribe() {
+    _state = initialStateFor(widget);
+    _subscription = streamFor(widget).listen((next) {
+      if (!mounted) return;
+      final previous = _state;
+      _state = next;
+      onState(previous, next);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- New `StreamBackedState<S, W>` mixin in `lib/src/builders/stream_backed_state.dart` owns the subscribe/resubscribe/cancel lifecycle.
- All five widgets (`TypedQueryBuilder`, `TypedMutationBuilder`, `TypedInfiniteQueryBuilder`, `TypedQueryListener`, `TypedMutationListener`) now use it. Behaviour is unchanged.

## Test plan
- [x] `flutter test` — 117 / 117 pass.
- [x] `dart analyze --fatal-infos lib/` — clean.

Closes #11