### PR TITLE
fix(api): unify keyGenerator contract across serializables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ class GetUserRequest extends QuerySerializable<User, ApiError> {
   GetUserRequest({required this.userId, required this.apiService});
 
   @override
-  String keyGenerator() => 'user_$userId';
+  String get keyGenerator => 'user_$userId';
 
   @override
   QueryException errorMapper(ApiError error) => 
@@ -117,7 +117,7 @@ class UpdateUserRequest extends MutationSerializable<UpdateUserRequest, User, Ap
   UpdateUserRequest({required this.name, required this.email, required this.apiService});
 
   @override
-  String keyGenerator() => 'update_user';
+  String get keyGenerator => 'update_user';
 
   @override
   OnErrorResults<UpdateUserRequest, User?> errorMapper(

--- a/example/main.dart
+++ b/example/main.dart
@@ -137,7 +137,7 @@ class UpdateUserRequest extends MutationSerializable<UpdateUserRequest, User, Ap
   UpdateUserRequest({required this.name, required this.email, required this.apiService});
 
   @override
-  String keyGenerator() => 'update_user';
+  String get keyGenerator => 'update_user';
 
   @override
   OnErrorResults<UpdateUserRequest, User?> errorMapper(UpdateUserRequest request, ApiError error, User? fallback) {
@@ -162,7 +162,7 @@ class GetUsersPageRequest extends InfiniteQuerySerializable<List<User>, int, Api
   GetUsersPageRequest({required this.apiService});
 
   @override
-  String keyGenerator() => 'users_page';
+  String get keyGenerator => 'users_page';
 
   @override
   QueryException errorMapper(ApiError error) => QueryException('Failed to get users: ${error.message}', error.statusCode);

--- a/lib/src/models/infinite_query_key.dart
+++ b/lib/src/models/infinite_query_key.dart
@@ -6,7 +6,7 @@ class InfiniteQueryKey<RequestType extends InfiniteQuerySerializable<ReturnType,
   final RequestType request;
   InfiniteQueryKey(this.request);
 
-  String get _valueKey => request.keyGenerator();
+  String get _valueKey => request.keyGenerator;
   String get rawKey => _valueKey;
   CachedQuery get _cache => request.cache ?? CachedQuery.instance;
 

--- a/lib/src/models/mutation_key.dart
+++ b/lib/src/models/mutation_key.dart
@@ -13,7 +13,7 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
   final RequestType request;
   MutationKey(this.request);
 
-  String get _valueKey => request.keyGenerator();
+  String get _valueKey => request.keyGenerator;
 
   Mutation<ReturnType, RequestType> definition({
     void Function(RequestType, MutationException, ReturnType?)? onError,

--- a/lib/src/models/serializable.dart
+++ b/lib/src/models/serializable.dart
@@ -158,7 +158,7 @@ abstract class QuerySerializable<ReturnType, ErrorType> {
 ///   CreateUserMutation({required this.name, required this.email});
 ///
 ///   @override
-///   String keyGenerator() => 'create_user';
+///   String get keyGenerator => 'create_user';
 ///
 ///   @override
 ///   Future<User> mutationFn() => api.createUser(name: name, email: email);
@@ -194,8 +194,8 @@ abstract class MutationSerializable<RequestType extends MutationSerializable<Req
   /// can track in-flight state, deduplicate concurrent submissions, and dispatch optimistic updates.
   /// **Returns:** A stable, unique string per mutation type. Override per request only when the
   /// mutation is parameterised by data that should partition cache state (e.g. user id).
-  /// **Example:** `String keyGenerator() => 'create_user';`
-  String keyGenerator();
+  /// **Example:** `String get keyGenerator => 'create_user';`
+  String get keyGenerator;
 
   /// Maps a domain-specific [ErrorType] into a typed [OnErrorResults] for the mutation pipeline.
   ///
@@ -254,7 +254,7 @@ abstract class MutationSerializable<RequestType extends MutationSerializable<Req
 ///   GetUsersInfiniteQuery({this.pageSize = 20});
 ///
 ///   @override
-///   String keyGenerator() => 'users_infinite_$pageSize';
+///   String get keyGenerator => 'users_infinite_$pageSize';
 ///
 ///   @override
 ///   Future<PagedUsers> queryFn(int page) =>
@@ -294,8 +294,8 @@ abstract class InfiniteQuerySerializable<ReturnType, RequestData, ErrorType> {
   /// can track all loaded pages and dispatch updates correctly.
   /// **Returns:** A stable, unique string per infinite query type. Override per parameterised
   /// query so different page sizes, filters, or sort orders are cached separately.
-  /// **Example:** `String keyGenerator() => 'users_infinite_${pageSize}_$sortBy';`
-  String keyGenerator();
+  /// **Example:** `String get keyGenerator => 'users_infinite_${pageSize}_$sortBy';`
+  String get keyGenerator;
 
   /// Maps a domain-specific [ErrorType] into a [QueryException] for consistent error handling.
   ///

--- a/test/data/models/create_user_request.dart
+++ b/test/data/models/create_user_request.dart
@@ -17,7 +17,7 @@ class CreateUserRequest extends MutationSerializable<CreateUserRequest, User, Va
   MutationCache? get cache => _cache;
 
   @override
-  String keyGenerator() => 'create_user_${name}_${DateTime.now().millisecondsSinceEpoch}';
+  String get keyGenerator => 'create_user_${name}_${DateTime.now().millisecondsSinceEpoch}';
 
   @override
   OnErrorResults<CreateUserRequest, User?> errorMapper(CreateUserRequest request, ValidationError error, User? fallback) {

--- a/test/data/models/retryable_create_user_request.dart
+++ b/test/data/models/retryable_create_user_request.dart
@@ -18,7 +18,7 @@ class RetryableCreateUserRequest extends MutationSerializable<RetryableCreateUse
   MutationCache? get cache => _cache;
 
   @override
-  String keyGenerator() => 'retryable_create_$name';
+  String get keyGenerator => 'retryable_create_$name';
 
   @override
   OnErrorResults<RetryableCreateUserRequest, User?> errorMapper(RetryableCreateUserRequest request, NetworkError error, User? fallback) {

--- a/test/data/models/update_user_request.dart
+++ b/test/data/models/update_user_request.dart
@@ -18,7 +18,7 @@ class UpdateUserRequest extends MutationSerializable<UpdateUserRequest, User, Ap
   MutationCache? get cache => _cache;
 
   @override
-  String keyGenerator() => 'update_user_$id';
+  String get keyGenerator => 'update_user_$id';
 
   @override
   OnErrorResults<UpdateUserRequest, User?> errorMapper(UpdateUserRequest request, ApiError error, User? fallback) {

--- a/test/src/models/infinite_query_key_test.dart
+++ b/test/src/models/infinite_query_key_test.dart
@@ -84,7 +84,7 @@ class GetUsersInfiniteQuery extends InfiniteQuerySerializable<PagedResponse, Pag
   GetUsersInfiniteQuery({required this.apiService, required this.localCache});
 
   @override
-  String keyGenerator() => 'users_infinite';
+  String get keyGenerator => 'users_infinite';
 
   @override
   QueryException errorMapper(ApiError error) => QueryException('API Error: ${error.message}', error.code);
@@ -143,7 +143,7 @@ class _ThrowingGetNextArgQuery extends InfiniteQuerySerializable<PagedResponse, 
   _ThrowingGetNextArgQuery({required this.localCache, required this.errorToThrow});
 
   @override
-  String keyGenerator() => 'throwing_get_next_arg';
+  String get keyGenerator => 'throwing_get_next_arg';
   @override
   QueryException errorMapper(ApiError error) => QueryException('API Error: ${error.message}', error.code);
   @override

--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -68,7 +68,7 @@ class CreateUserMutation extends MutationSerializable<CreateUserMutation, User, 
   CreateUserMutation({required this.request, required this.apiService, MutationCache? cache}) : _cache = cache;
 
   @override
-  String keyGenerator() => 'create_user_${request.name}_${request.email}';
+  String get keyGenerator => 'create_user_${request.name}_${request.email}';
 
   @override
   OnErrorResults<CreateUserMutation, User?> errorMapper(CreateUserMutation request, ValidationError error, User? fallback) {

--- a/test/src/models/serializable_test.dart
+++ b/test/src/models/serializable_test.dart
@@ -91,7 +91,7 @@ class TestMutationSerializable extends MutationSerializable<TestMutationSerializ
   TestMutationSerializable({required this.request});
 
   @override
-  String keyGenerator() => 'test_create_user_${request.name}';
+  String get keyGenerator => 'test_create_user_${request.name}';
 
   @override
   OnErrorResults<TestMutationSerializable, User?> errorMapper(TestMutationSerializable request, ApiError error, User? fallback) {
@@ -189,7 +189,15 @@ void main() {
       final request = CreateUserRequest(name: 'John', email: 'john@example.com');
       final mutationSerializable = TestMutationSerializable(request: request);
 
-      expect(mutationSerializable.keyGenerator(), 'test_create_user_John');
+      expect(mutationSerializable.keyGenerator, 'test_create_user_John');
+    });
+
+    test('keyGenerator is a getter (contract — same shape as QuerySerializable)', () {
+      // If keyGenerator regresses to a method form, this static-typed access would not compile.
+      final request = CreateUserRequest(name: 'A', email: 'a@b.c');
+      final m = TestMutationSerializable(request: request);
+      final String key = m.keyGenerator;
+      expect(key, isNotEmpty);
     });
 
     test('should map errors correctly', () {
@@ -319,7 +327,7 @@ void main() {
       final mutationSerializable = TestMutationSerializable(request: request);
 
       // Test full workflow
-      final key = mutationSerializable.keyGenerator();
+      final key = mutationSerializable.keyGenerator;
       final mutationResult = await mutationSerializable.mutationFn();
       final processedResult = mutationSerializable.responseHandler(mutationResult);
 


### PR DESCRIPTION
## Summary
- Make `keyGenerator` a getter on all three abstract base classes (`QuerySerializable` was already a getter; `MutationSerializable` and `InfiniteQuerySerializable` were methods).
- Update internal callers and every consumer-implemented fixture, including test data, test-internal mocks, the example app, and README samples.

## Breaking change
Downstream implementers must change `String keyGenerator() => ...` overrides on `MutationSerializable` and `InfiniteQuerySerializable` to `String get keyGenerator => ...`.

## Test plan
- [x] Contract test added asserting the getter shape.
- [x] `flutter test` — 118 / 118 pass.
- [x] `dart analyze --fatal-infos lib/` — clean.

Closes #2