### PR TITLE
refactor(serializable): single path to obtain QueryKey (extension only)

### DIFF
--- a/lib/src/models/serializable.dart
+++ b/lib/src/models/serializable.dart
@@ -39,7 +39,7 @@ import 'package:typed_cached_query/src/models/infinite_query_key.dart';
 /// ## Usage
 /// ```dart
 /// final query = GetUserQuery(123);
-/// final result = await query.query().result;
+/// final result = await query.queryKey.query().result;
 /// ```
 ///
 /// ## Advanced Features
@@ -84,14 +84,6 @@ abstract class QuerySerializable<ReturnType, ErrorType> {
   /// **Error handling:** Should throw errors of type [ErrorType] for proper error mapping
   /// **Example:** HTTP client calls, database operations, file system access
   Future<dynamic> queryFn();
-
-  Query<ReturnType> Function({
-    void Function(QueryException)? onError,
-    void Function(ReturnType)? onSuccess,
-    QueryConfig<ReturnType>? config,
-    CachedQuery? cache,
-  })
-  get query => QueryKey(this).query;
 
   /// Serializes this request object into a JSON-compatible map.
   ///


### PR DESCRIPTION
## Summary
- Remove the redundant `query` function-getter on `QuerySerializable`. The `queryKey` extension is now the single canonical path, matching the shape of `MutationSerializable.mutationKey` and `InfiniteQuerySerializable.infiniteQueryKey`.
- Update dartdoc usage example.

## Test plan
- [x] `flutter test` — 118 / 118 pass.
- [x] `dart analyze --fatal-infos lib/` — clean.
- [x] No call site of the function-getter exists in lib/, test/, or example/.

Closes #12