### PR TITLE
chore: minor cleanup umbrella

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@ This package abstracts away the complexity of cached_query_flutter while providi
 - **Testing support**: Easy-to-mock interfaces for unit testing
 - **Flutter integration**: Seamless integration with Flutter lifecycle and connectivity
 
-## Getting started
-
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
-
 ## Getting Started
 
 ### Installation

--- a/lib/src/models/mutation_key.dart
+++ b/lib/src/models/mutation_key.dart
@@ -41,38 +41,28 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
     return Mutation<ReturnType, RequestType>(
       key: _valueKey,
       mutationFn: (requestParam) async {
-        int attempts = 0;
         final maxAttempts = (retryAttempts ?? 0) + 1;
-
-        while (attempts < maxAttempts) {
+        for (var attempt = 1; attempt <= maxAttempts; attempt++) {
           try {
-            final result = timeoutSeconds != null
+            return timeoutSeconds != null
                 ? await request.mutationFn().timeout(Duration(seconds: timeoutSeconds))
                 : await request.mutationFn();
-
-            return result;
           } catch (e) {
-            attempts++;
-
-            if (e is TimeoutException && capturedOnTimeout != null) {
-              rethrow;
-            }
-
-            // Handle unhandled exceptions (fail fast)
+            if (e is TimeoutException && capturedOnTimeout != null) rethrow;
             if (e is! ErrorType) {
               throw MutationException(
                 'An unhandled exception has taken place, please update your definitions for ${request.runtimeType} to include this error, error: ${e.toString()}',
                 500,
               );
             }
-            if (shouldRetry == null || attempts >= maxAttempts || !shouldRetry(e as ErrorType)) rethrow;
-
-            await Future<void>.delayed(backoffFn(attempts));
-            continue;
+            final canRetry = shouldRetry != null && attempt < maxAttempts && shouldRetry(e as ErrorType);
+            if (!canRetry) rethrow;
+            await Future<void>.delayed(backoffFn(attempt));
           }
         }
-
-        throw StateError('Retry loop completed without return or throw');
+        // Unreachable: the loop body always exits via `return` or `rethrow` on the final attempt.
+        // Dart's flow analysis does not see this, so a terminator is required.
+        throw StateError('unreachable: mutation retry loop completed without returning or throwing');
       },
       onError: (requestParam, error, fallback) {
         if (error is MutationException || error is ArgumentError) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,9 @@
 name: typed_cached_query
 description: "A type-safe wrapper around cached_query_flutter that provides a clean, strongly-typed API for managing queries and mutations in Flutter applications."
 version: 0.0.1
-homepage:
+homepage: https://github.com/ChristopherLinnett/typed_cached_query
+repository: https://github.com/ChristopherLinnett/typed_cached_query
+issue_tracker: https://github.com/ChristopherLinnett/typed_cached_query/issues
 
 environment:
   sdk: ^3.10.3


### PR DESCRIPTION
## Summary
- **m1** — restructure the mutation retry loop into a for-with-attempt-index; clarify the trailing unreachable terminator with a comment explaining Dart flow analysis.
- **m5** — add `homepage`, `repository`, `issue_tracker` URLs to `pubspec.yaml`.
- **m6** — drop the duplicate 'Getting started' heading and its TODO from the README.

m2, m3, m4 already resolved in earlier PRs (#20, #22, #11). m7 (test-mock lint warnings) and m8 (inline test fixtures) are intentionally deferred — both are auto-generated/test-only and CI already scopes `--fatal-infos` to `lib/`.

## Test plan
- [x] `flutter test` — 118 / 118 pass.
- [x] `dart analyze --fatal-infos lib/` — clean.

Closes #18