### PR TITLE
refactor(test-fixture): drop unnecessary async on synchronous queryFn helper

### DIFF
--- a/test/src/models/query_key_test.dart
+++ b/test/src/models/query_key_test.dart
@@ -390,7 +390,7 @@ class _BadResponseQuery extends QuerySerializable<User, ApiError> {
   QueryException errorMapper(ApiError error) => QueryException(error.message, error.code);
 
   @override
-  Future<dynamic> queryFn() async => apiService.getUser(1);
+  Future<dynamic> queryFn() => apiService.getUser(1);
 
   @override
   User responseHandler(dynamic response) => throw Exception('responseHandler intentionally failed');


### PR DESCRIPTION
## Summary
Drops `async` from the `_BadResponseQuery` helper.

## Test plan
- [x] `flutter test` — pass.

Closes #63