### PR TITLE
ci: run on all pushes and pull requests, not just main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
Drop the `branches: [main]` filter so the workflow runs on every push (and PR), matching the README description.

## Test plan
- [x] This very push will trigger the broadened workflow — verifiable in the Actions tab once merged (or via the PR's Checks tab once the workflow runs against the PR branch).

Closes #53