### PR TITLE
fix(error-getters): defensive type branching across all three Key types

### DIFF
--- a/lib/src/models/infinite_query_key.dart
+++ b/lib/src/models/infinite_query_key.dart
@@ -101,8 +101,14 @@ class InfiniteQueryKey<RequestType extends InfiniteQuerySerializable<ReturnType,
     return state is InfiniteQuerySuccess<ReturnType, RequestData> && !state.hasNextPage;
   }
 
-  QueryException? get error =>
-      _getInfiniteQuery == null || !_getInfiniteQuery!.state.isError ? null : request.errorMapper(_getInfiniteQuery!.state.error! as ErrorType);
+  QueryException? get error {
+    if (_getInfiniteQuery == null) return null;
+    final stateError = _getInfiniteQuery!.state.error;
+    if (stateError == null) return null;
+    if (stateError is QueryException) return stateError;
+    if (stateError is ErrorType) return request.errorMapper(stateError);
+    return QueryException('Unhandled error: $stateError', 500);
+  }
 
   /// Get all pages as a flat list
   List<ReturnType> get allPages {

--- a/lib/src/models/mutation_key.dart
+++ b/lib/src/models/mutation_key.dart
@@ -121,7 +121,13 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
 
   bool get isError => _getMutation != null && _getMutation!.state.isError;
 
-  MutationException? get error => _getMutation == null || _getMutation!.state is! MutationError
-      ? null
-      : request.errorMapper(request, (_getMutation!.state as MutationError).error as ErrorType, null).error;
+  MutationException? get error {
+    if (_getMutation == null) return null;
+    final state = _getMutation!.state;
+    if (state is! MutationError) return null;
+    final stateError = state.error;
+    if (stateError is MutationException) return stateError;
+    if (stateError is ErrorType) return request.errorMapper(request, stateError, null).error;
+    return MutationException('Unhandled error: $stateError', 500);
+  }
 }

--- a/lib/src/models/query_key.dart
+++ b/lib/src/models/query_key.dart
@@ -85,7 +85,14 @@ class QueryKey<RequestType extends QuerySerializable<ReturnType, ErrorType>, Ret
   bool get isPending => _getQuery != null && _getQuery!.state.isLoading && _getQuery!.state.data == null;
   bool get isRefetching => _getQuery != null && _getQuery!.state.isLoading && _getQuery!.state.data != null;
   bool get isError => _getQuery != null && _getQuery!.state.isError;
-  QueryException? get error => _getQuery == null || !_getQuery!.state.isError ? null : request.errorMapper(_getQuery!.state.error! as ErrorType);
+  QueryException? get error {
+    if (_getQuery == null) return null;
+    final stateError = _getQuery!.state.error;
+    if (stateError == null) return null;
+    if (stateError is QueryException) return stateError;
+    if (stateError is ErrorType) return request.errorMapper(stateError);
+    return QueryException('Unhandled error: $stateError', 500);
+  }
 
   T updateData<T>(T Function(ReturnType? existingData) updateFunction) {
     if (_getQuery == null) {

--- a/test/src/models/infinite_query_key_test.dart
+++ b/test/src/models/infinite_query_key_test.dart
@@ -429,6 +429,23 @@ void main() {
       expect(query.state.error, isNotNull);
     });
 
+    test('error getter does not throw when state.error is a QueryException (unknown-type path)', () async {
+      // After getNextArg wraps an unknown error as QueryException, the underlying state.error is
+      // a QueryException rather than ErrorType. The previous force-cast would TypeError here.
+      final request = _ThrowingGetNextArgQuery(localCache: cachedQuery, errorToThrow: StateError('unexpected'));
+      final infiniteQueryKey = InfiniteQueryKey(request);
+      final query = infiniteQueryKey.query();
+
+      await query.fetch();
+      try {
+        await query.getNextPage();
+      } catch (_) {/* expected */}
+
+      // The defensive error getter must return the QueryException as-is (no cast, no crash).
+      expect(() => infiniteQueryKey.error, returnsNormally);
+      expect(infiniteQueryKey.error, isA<QueryException>());
+    });
+
     test('should invalidate query correctly', () async {
       final pageResponse = PagedResponse(
         users: [User(id: 1, name: 'John', email: 'john@example.com')],


### PR DESCRIPTION
## Summary
- `InfiniteQueryKey.error`, `QueryKey.error`, `MutationKey.error` no longer force-cast `state.error` to `ErrorType` — they now branch on the runtime type and pass through `QueryException`/`MutationException` unchanged, map `ErrorType` via `errorMapper`, and wrap unknown error objects in a generic `QueryException`/`MutationException`.

## Test plan
- [x] RED test added for the InfiniteQueryKey unknown-error path.
- [x] `flutter test` — 123/123 pass.
- [x] `dart analyze --fatal-infos lib/` — clean.

Closes #45