### PR TITLE
fix(query-key): handle async + non-ErrorType errors consistently

### DIFF
--- a/lib/src/models/query_key.dart
+++ b/lib/src/models/query_key.dart
@@ -35,29 +35,35 @@ class QueryKey<RequestType extends QuerySerializable<ReturnType, ErrorType>, Ret
     }
   }
 
-  Future<ReturnType> _wrappedQueryFn() {
+  Future<ReturnType> _wrappedQueryFn() async {
+    dynamic rawResponse;
     try {
-      return request.queryFn().then((response) {
-        try {
-          return request.responseHandler(response);
-        } catch (e) {
-          throw FormatException('parsing the response of type ${response.runtimeType} to $ReturnType failed: ${e.toString()}');
-        }
-      });
+      rawResponse = await request.queryFn();
     } catch (e) {
       if (e is ErrorType) rethrow;
-      if (e is FormatException) throw QueryException(e.message, 400);
       throw QueryException(
         'An unhandled exception has taken place, please update your definitions to include this error, error: ${e.toString()}',
         500,
       );
     }
+    try {
+      return request.responseHandler(rawResponse);
+    } catch (e) {
+      throw QueryException('parsing the response of type ${rawResponse.runtimeType} to $ReturnType failed: ${e.toString()}', 400);
+    }
   }
 
   void Function(dynamic) _wrappedOnError(void Function(QueryException)? userOnError) {
     return (error) {
-      if (error is QueryException) throw error;
-      userOnError?.call(request.errorMapper(error as ErrorType));
+      if (error is QueryException) {
+        userOnError?.call(error);
+        return;
+      }
+      if (error is ErrorType) {
+        userOnError?.call(request.errorMapper(error));
+        return;
+      }
+      userOnError?.call(QueryException('An unhandled exception occurred: ${error.toString()}', 500));
     };
   }
 

--- a/test/src/models/query_key_test.dart
+++ b/test/src/models/query_key_test.dart
@@ -194,17 +194,41 @@ void main() {
       expect(capturedError!.statusCode, 404);
     });
 
-    test('should throw QueryException for unhandled errors', () async {
+    test('unhandled errors land in state as QueryException (no rethrow to the caller)', () async {
       when(mockApiService.getUser(789)).thenThrow(Exception('Unexpected error'));
 
       final request = GetUserQuery(userId: 789, apiService: mockApiService, localCache: cachedQuery);
       final queryKey = QueryKey(request);
       final query = queryKey.query();
 
-      expect(
-        () => query.fetch(),
-        throwsA(isA<QueryException>().having((e) => e.message, 'message', contains('An unhandled exception has taken place'))),
-      );
+      final result = await query.fetch();
+
+      expect(result.error, isA<QueryException>());
+      expect((result.error as QueryException).message, contains('An unhandled exception has taken place'));
+    });
+
+    test('async queryFn throwing a non-ErrorType lands as QueryException (no TypeError)', () async {
+      // The previous _wrappedQueryFn try/catch only caught synchronous throws of queryFn(); an async
+      // queryFn that threw AFTER an await emitted the original error untouched, and the onError
+      // closure then force-cast it to ErrorType — TypeError, original error swallowed.
+      when(mockApiService.getUser(321)).thenAnswer((_) async {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+        throw FormatException('parse boom');
+      });
+
+      final request = GetUserQuery(userId: 321, apiService: mockApiService, localCache: cachedQuery);
+      final query = request.queryKey.query();
+
+      Object? captured;
+      try {
+        await query.fetch();
+      } catch (e) {
+        captured = e;
+      }
+
+      final stateOrCaught = query.state.error ?? captured;
+      expect(stateOrCaught, isA<QueryException>(),
+          reason: 'async non-ErrorType errors must be wrapped as QueryException, not surface as TypeError or the raw exception');
     });
 
     test('FormatException message names the actual ReturnType (not the literal "Type")', () async {


### PR DESCRIPTION
## Summary
- Rewrite `_wrappedQueryFn` as async/await so async queryFn errors and sync responseHandler errors share one error-mapping path.
- Make `_wrappedOnError` defensive — pass through QueryException, map ErrorType via errorMapper, wrap unknown errors as generic QueryException (mirrors InfiniteQueryKey).
- Update the 'should throw QueryException for unhandled errors' test to assert the new shape: errors land in QueryStatus.error rather than rejecting the fetch() future.
- Adds the async-non-ErrorType regression test from #59.

## Test plan
- [x] RED test added.
- [x] flutter test — 124/124 pass.
- [x] dart analyze --fatal-infos lib/ — clean.

Closes #46
Closes #59