### PR TITLE
test: rename misleading test titles

### DIFF
--- a/test/src/builders/mutation_listener_test.dart
+++ b/test/src/builders/mutation_listener_test.dart
@@ -70,10 +70,11 @@ void main() {
     expect(successes, 2, reason: 'a second mutate cycle adds exactly one further success transition');
   });
 
-  testWidgets('onSuccess does not fire on a stream replay of the same success state (didUpdateWidget swap to same mutation result)', (tester) async {
+  testWidgets('onSuccess does not fire when a late listener receives a replay of the current success state', (tester) async {
     final mutation = _makeMutation(cache, 'ml-replay', (i) async => 'ok-$i');
     await mutation.mutate(1);
-    // Wait for completion before listener attaches — listener attaches AFTER state is success.
+    // Complete the mutation BEFORE attaching the listener, so the subscription receives a
+    // BehaviorSubject replay of the success state. Pre-fix, this fired onSuccess for a non-transition.
 
     var successes = 0;
     await tester.pumpWidget(

--- a/test/src/models/serializable_test.dart
+++ b/test/src/models/serializable_test.dart
@@ -284,7 +284,7 @@ void main() {
       expect(result.fallback, null);
     });
 
-    test('OnErrorResults exposes final fields (read-only after construction)', () {
+    test('OnErrorResults stores fields by reference without copying', () {
       final request = CreateUserRequest(name: 'A', email: 'a@b.c');
       final mutationSerializable = TestMutationSerializable(request: request);
       final error = MutationException('e', 500);


### PR DESCRIPTION
## Summary
- Rename two tests so their titles describe what their assertions actually verify (per PR #27 and #38 reviews).

## Test plan
- [x] No logic change.
- [x] flutter test — pass.

Closes #62