### PR TITLE
docs+test(mutation-key): unbreak [backoff] dartdoc; rename default-backoff test

### DIFF
--- a/lib/src/models/mutation_key.dart
+++ b/lib/src/models/mutation_key.dart
@@ -5,7 +5,7 @@ import 'package:typed_cached_query/src/errors/query_exception.dart';
 import 'package:typed_cached_query/src/models/query_key.dart';
 import 'package:typed_cached_query/src/models/serializable.dart';
 
-/// Default linear backoff used when no [backoff] is supplied: 100 ms × attempt.
+/// Default linear backoff used when no `backoff` is supplied: 100 ms × attempt.
 /// `attempt` is 1-based — i.e. called with 1 between attempts 1 and 2, 2 between 2 and 3, etc.
 Duration defaultMutationBackoff(int attempt) => Duration(milliseconds: 100 * attempt);
 

--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -253,7 +253,7 @@ void main() {
   });
 
   group('MutationKey Backoff', () {
-    test('uses defaultMutationBackoff when no backoff is provided', () async {
+    test('retries succeed when no backoff is provided (default behaviour preserved)', () async {
       final request = CreateUserRequest(name: 'Bo', email: 'bo@example.com');
       final user = User(id: 1, name: 'Bo', email: 'bo@example.com');
       var calls = 0;


### PR DESCRIPTION
## Summary
- `[backoff]` → ``backoff`` in mutation_key.dart dartdoc.
- Rename the misleading test that asserted only retry success, not backoff strategy.

## Test plan
- [x] flutter test — pass.
- [x] dart analyze --fatal-infos lib/ — clean.

Closes #57