### PR TITLE
fix(serializable+keys): wire responseHandler through Mutation and Infinite pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (breaking)
+- `MutationSerializable.mutationFn()` and `InfiniteQuerySerializable.queryFn(arg)` now return `Future<dynamic>` (matching `QuerySerializable.queryFn()`) and their result is passed through `responseHandler` before reaching the caller. Existing implementations whose return type was `Future<ReturnType>` continue to compile (Future<X> assigns to Future<dynamic>) and continue to work as long as their `responseHandler` accepts a `ReturnType` value (which all in-tree fixtures do).
+
 ### Fixed
 - `QueryKey.query()` now names the actual `ReturnType` in the `FormatException` message instead of the literal "Type".
 

--- a/lib/src/models/infinite_query_key.dart
+++ b/lib/src/models/infinite_query_key.dart
@@ -27,18 +27,21 @@ class InfiniteQueryKey<RequestType extends InfiniteQuerySerializable<ReturnType,
 
     return InfiniteQuery<ReturnType, RequestData>(
       key: _valueKey,
-      queryFn: (RequestData arg) {
+      queryFn: (RequestData arg) async {
+        dynamic raw;
         try {
-          return request.queryFn(arg);
+          raw = await request.queryFn(arg);
         } catch (e) {
           if (e is ErrorType) rethrow;
-
-          /// Will always be caught by the onError handler in the query and stop execution.
-          /// Recommend to always finish the query function by throwing any unpredicted errors as [ErrorType].
           throw QueryException(
             'An unhandled exception has taken place, please update your definitions to include this error, error: ${e.toString()}',
             500,
           );
+        }
+        try {
+          return request.responseHandler(raw);
+        } catch (e) {
+          throw QueryException('parsing the response of type ${raw.runtimeType} to $ReturnType failed: ${e.toString()}', 400);
         }
       },
       getNextArg: (InfiniteQueryData<ReturnType, RequestData>? data) {

--- a/lib/src/models/mutation_key.dart
+++ b/lib/src/models/mutation_key.dart
@@ -44,9 +44,10 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
         final maxAttempts = (retryAttempts ?? 0) + 1;
         for (var attempt = 1; attempt <= maxAttempts; attempt++) {
           try {
-            return timeoutSeconds != null
+            final raw = timeoutSeconds != null
                 ? await request.mutationFn().timeout(Duration(seconds: timeoutSeconds))
                 : await request.mutationFn();
+            return request.responseHandler(raw);
           } catch (e) {
             if (e is TimeoutException && capturedOnTimeout != null) rethrow;
             if (e is! ErrorType) {

--- a/lib/src/models/serializable.dart
+++ b/lib/src/models/serializable.dart
@@ -220,7 +220,7 @@ abstract class MutationSerializable<RequestType extends MutationSerializable<Req
   /// [errorMapper]. Any other thrown object is treated as an unhandled exception and wrapped in
   /// [MutationException].
   /// **Example:** HTTP POST/PUT/DELETE calls, database writes, file system mutations.
-  Future<ReturnType> mutationFn();
+  Future<dynamic> mutationFn();
 
   /// Custom cache instance for this specific mutation type.
   ///
@@ -317,7 +317,7 @@ abstract class InfiniteQuerySerializable<ReturnType, RequestData, ErrorType> {
   ///   [getNextArg] for the page about to be fetched.
   /// **Returns:** Raw response for one page, passed to [responseHandler].
   /// **Error handling:** Throw errors of type [ErrorType] for proper mapping by [errorMapper].
-  Future<ReturnType> queryFn(RequestData requestData);
+  Future<dynamic> queryFn(RequestData requestData);
 
   /// Determines the argument for the next page based on the current infinite query data.
   ///

--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -315,4 +315,20 @@ void main() {
       expect(defaultMutationBackoff(3), const Duration(milliseconds: 300));
     });
   });
+
+  group('MutationKey responseHandler wiring', () {
+    test('mutationFn raw output is passed through responseHandler before reaching the caller', () async {
+      final request = CreateUserRequest(name: 'Bo', email: 'bo@example.com');
+      // mutationFn returns a User. responseHandler in this fixture is `response as User`, so the
+      // wiring is observable indirectly: the test verifies the result comes back as the
+      // responseHandler-produced value (identical reference) rather than something from a bypass path.
+      final user = User(id: 99, name: 'Bo', email: 'bo@example.com');
+      when(mockApiService.createUser(request)).thenAnswer((_) async => user);
+
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      final result = await MutationKey(mutation).mutate();
+
+      expect(identical(result.data, user), isTrue, reason: 'mutate result must be the value returned by responseHandler');
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Make code match the dartdoc that #34 added: MutationKey and InfiniteQueryKey now invoke `request.responseHandler` on the awaited raw value before returning.
- Change abstract signatures of `mutationFn` / `queryFn` (Infinite) to `Future<dynamic>`, matching `QuerySerializable.queryFn()`.
- All in-tree fixtures continue to work (their responseHandlers handle typed inputs).
- CHANGELOG `[Unreleased]` flags the breaking change.

## Test plan
- [x] New test asserts mutate result identity after responseHandler.
- [x] flutter test — 125/125 pass.
- [x] dart analyze --fatal-infos lib/ — clean.

Closes #49