### PR TITLE
test(builders): tighten lifecycle assertions across builders/listeners

### DIFF
--- a/test/src/builders/infinite_query_builder_test.dart
+++ b/test/src/builders/infinite_query_builder_test.dart
@@ -3,11 +3,11 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:typed_cached_query/src/builders/infinite_query_builder.dart';
 
-InfiniteQuery<String, int> _makeInfinite(CachedQuery cache, String key, {required int maxPage}) {
+InfiniteQuery<String, int> _makeInfinite(CachedQuery cache, String key, {required int maxPage, String prefix = 'page'}) {
   return InfiniteQuery<String, int>(
     cache: cache,
     key: key,
-    queryFn: (page) async => 'page-$page',
+    queryFn: (page) async => '$prefix-$page',
     getNextArg: (data) {
       if (data == null || data.pages.isEmpty) return 1;
       final next = data.args.last + 1;
@@ -48,7 +48,7 @@ void main() {
   testWidgets('fetchNextPage callback advances pagination', (tester) async {
     final query = _makeInfinite(cache, 'iq-paginate', maxPage: 3);
 
-    Future<dynamic> Function()? capturedNext;
+    Future<InfiniteQueryStatus<String, int>?> Function()? capturedNext;
     await tester.pumpWidget(
       _harness(
         TypedInfiniteQueryBuilder<String, int>(
@@ -69,8 +69,8 @@ void main() {
   });
 
   testWidgets('didUpdateWidget swaps subscription when the query changes', (tester) async {
-    final qa = _makeInfinite(cache, 'iq-A', maxPage: 1);
-    final qb = _makeInfinite(cache, 'iq-B', maxPage: 1);
+    final qa = _makeInfinite(cache, 'iq-A', maxPage: 2, prefix: 'A');
+    final qb = _makeInfinite(cache, 'iq-B', maxPage: 2, prefix: 'B');
 
     Widget under(InfiniteQuery<String, int> q) => _harness(
       TypedInfiniteQueryBuilder<String, int>(
@@ -81,14 +81,21 @@ void main() {
 
     await tester.pumpWidget(under(qa));
     await tester.pumpAndSettle();
-    expect(find.text('page-1'), findsOneWidget);
+    expect(find.text('A-1'), findsOneWidget);
 
     await tester.pumpWidget(under(qb));
     await tester.pumpAndSettle();
-    expect(find.text('page-1'), findsOneWidget);
+    expect(find.text('B-1'), findsOneWidget);
+
+    // Drive the OLD query (qa) and assert the UI does not react — proves the swap dropped the
+    // old subscription rather than just ending up at the same value by coincidence.
+    await qa.refetch();
+    await tester.pumpAndSettle();
+    expect(find.text('B-1'), findsOneWidget);
+    expect(find.text('A-1'), findsNothing);
   });
 
-  testWidgets('dispose cancels subscription', (tester) async {
+  testWidgets('dispose-time mounted guard suppresses post-dispose setState', (tester) async {
     final query = _makeInfinite(cache, 'iq-dispose', maxPage: 1);
     await tester.pumpWidget(
       _harness(

--- a/test/src/builders/mutation_builder_test.dart
+++ b/test/src/builders/mutation_builder_test.dart
@@ -63,9 +63,15 @@ void main() {
     await m2.mutate(9);
     await tester.pumpAndSettle();
     expect(find.text('2-9'), findsOneWidget);
+
+    // Drive the OLD mutation after the swap and assert the UI does not react.
+    await m1.mutate(7);
+    await tester.pumpAndSettle();
+    expect(find.text('2-9'), findsOneWidget);
+    expect(find.text('1-7'), findsNothing);
   });
 
-  testWidgets('dispose cancels the subscription so post-dispose events do not throw', (tester) async {
+  testWidgets('dispose-time mounted guard suppresses post-dispose setState', (tester) async {
     final mutation = _makeMutation(cache, 'm-dispose', (i) async {
       await Future<void>.delayed(const Duration(milliseconds: 5));
       return 'late-$i';

--- a/test/src/builders/mutation_listener_test.dart
+++ b/test/src/builders/mutation_listener_test.dart
@@ -93,6 +93,23 @@ void main() {
     expect(successes, 0, reason: 'replayed success state with no actual transition must not fire onSuccess');
   });
 
+  testWidgets('onLoading fires once on the loading transition of a mutation', (tester) async {
+    final mutation = _makeMutation(cache, 'ml-loading', (i) async => 'ok-$i');
+    var loadings = 0;
+    await tester.pumpWidget(
+      _harness(
+        TypedMutationListener<String, int>(
+          mutation: mutation,
+          onLoading: (_, _) => loadings += 1,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    await mutation.mutate(1);
+    await tester.pumpAndSettle();
+    expect(loadings, 1, reason: 'a mutate cycle must fire onLoading exactly once on the loading transition');
+  });
+
   testWidgets('onError fires after a failing mutation', (tester) async {
     final mutation = _makeMutation(cache, 'ml-error', (i) async => throw StateError('nope'));
     var errors = 0;
@@ -137,9 +154,14 @@ void main() {
 
     expect(dataA, dataABeforeSwap, reason: 'after swap, the old subscription must not deliver events');
     expect(dataB, greaterThanOrEqualTo(1));
+
+    // Drive the OLD mutation again — the old onData must remain silent.
+    await ma.mutate(3);
+    await tester.pumpAndSettle();
+    expect(dataA, dataABeforeSwap, reason: 'after swap, mutating the OLD instance must not deliver events to the old onData');
   });
 
-  testWidgets('dispose cancels the subscription', (tester) async {
+  testWidgets('dispose-time mounted guard suppresses post-dispose setState', (tester) async {
     final mutation = _makeMutation(cache, 'ml-dispose', (i) async {
       await Future<void>.delayed(const Duration(milliseconds: 5));
       return 'late-$i';

--- a/test/src/builders/query_builder_test.dart
+++ b/test/src/builders/query_builder_test.dart
@@ -62,9 +62,20 @@ void main() {
     await tester.pumpWidget(under(queryB));
     await tester.pumpAndSettle();
     expect(find.text('B'), findsOneWidget);
+
+    // Drive a state change on the OLD query and assert the UI does not react — proves the
+    // old subscription is gone, not just that the new query happens to render the same value.
+    queryA.update((_) => 'A-updated');
+    await tester.pumpAndSettle();
+    expect(find.text('B'), findsOneWidget);
+    expect(find.text('A-updated'), findsNothing);
   });
 
-  testWidgets('dispose cancels the subscription so post-dispose stream events do not throw', (tester) async {
+  testWidgets('dispose-time mounted guard suppresses post-dispose setState', (tester) async {
+    // The widget guards setState with `if (mounted)`, so this test exercises the mounted-guard
+    // path — it does not (and cannot from outside the widget) directly observe StreamSubscription
+    // cancellation. A leaked subscription would be silent here; what we are protecting against is
+    // a thrown exception from setState-after-dispose.
     final query = _makeQuery(cache, 'q-dispose', () async {
       await Future<void>.delayed(const Duration(milliseconds: 5));
       return 'late';
@@ -78,9 +89,7 @@ void main() {
         ),
       ),
     );
-    // Replace with an empty widget — disposes the State.
     await tester.pumpWidget(_harness(const SizedBox.shrink()));
-    // Allow the queryFn future to complete; if dispose forgot to cancel, the late setState would throw.
     await tester.pumpAndSettle();
   });
 }

--- a/test/src/builders/query_listener_test.dart
+++ b/test/src/builders/query_listener_test.dart
@@ -171,9 +171,14 @@ void main() {
 
     expect(changesA, changesABeforeSwap, reason: 'after swap, the old subscription must not deliver events');
     expect(changesB, greaterThanOrEqualTo(1));
+
+    // Drive the OLD query and assert the old onChange remains silent.
+    qa.update((_) => 'a-updated');
+    await tester.pumpAndSettle();
+    expect(changesA, changesABeforeSwap);
   });
 
-  testWidgets('dispose cancels the subscription', (tester) async {
+  testWidgets('dispose-time mounted guard suppresses post-dispose setState', (tester) async {
     final query = _makeQuery(cache, 'ql-dispose', () async {
       await Future<void>.delayed(const Duration(milliseconds: 5));
       return 'late';


### PR DESCRIPTION
## Summary
- All swap tests now drive the OLD input after swapping and assert silence.
- All dispose tests renamed to reflect what they actually prove (mounted-guard semantics).
- New TypedMutationListener onLoading test.
- TypedInfiniteQueryBuilder swap fixtures distinguishable; capturedNext typed exactly.

## Test plan
- [x] flutter test — 126/126 pass.
- [x] dart analyze --fatal-infos lib/ — clean.

Closes #61