### PR TITLE
chore(analysis): exclude test/fixtures/ from project-wide analysis

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,11 @@ include: package:flutter_lints/flutter.yaml
 # https://dart.dev/guides/language/analysis-options
 
 analyzer:
+  # Fixtures under test/fixtures/ are intentionally broken — they're regression inputs for tests
+  # that shell out to `dart analyze <fixture>` to assert specific diagnostics. Exclude them from
+  # project-wide analysis so IDEs and bare `dart analyze` don't surface them as errors.
+  exclude:
+    - test/fixtures/**
   language:
     strict-casts: true
     strict-inference: true


### PR DESCRIPTION
## Summary
- Add `analyzer.exclude: test/fixtures/**` so the deliberately-broken CRTP fixture stops surfacing in IDEs and bare `dart analyze`.
- Targeted `dart analyze test/fixtures/<file>` (used by `serializable_crtp_misdeclaration_test.dart`) still reports the diagnostics — verified locally.

## Test plan
- [x] `dart analyze` (bare) — fixture errors no longer present.
- [x] `dart analyze test/fixtures/bad_mutation_serializable_crtp.dart` — still produces the expected 2 errors.
- [x] CRTP analyzer test — pass.