### PR TITLE
docs(serializable): align mutationFn/queryFn header dartdoc with Future<dynamic> + responseHandler pipeline

### DIFF
--- a/lib/src/models/serializable.dart
+++ b/lib/src/models/serializable.dart
@@ -211,7 +211,8 @@ abstract class MutationSerializable<RequestType extends MutationSerializable<Req
   /// **Example:** `User responseHandler(dynamic response) => User.fromJson(response);`
   ReturnType responseHandler(dynamic response);
 
-  /// The core function that performs the mutation and returns a [Future] of [ReturnType].
+  /// The core function that performs the mutation. Returns a [Future] whose raw result is then
+  /// passed through [responseHandler] to produce the typed [ReturnType].
   ///
   /// **Purpose:** Contains your business logic for performing the mutation (HTTP requests,
   /// database writes, etc.).
@@ -308,7 +309,8 @@ abstract class InfiniteQuerySerializable<ReturnType, RequestData, ErrorType> {
   /// **Example:** `PagedResponse responseHandler(dynamic response) => PagedResponse.fromJson(response);`
   ReturnType responseHandler(dynamic response);
 
-  /// The core function that fetches a single page/chunk and returns a [Future] of [ReturnType].
+  /// The core function that fetches a single page/chunk. Returns a [Future] whose raw result is
+  /// then passed through [responseHandler] to produce the typed [ReturnType].
   ///
   /// **Purpose:** Contains your business logic for fetching a specific page given the page-pointer
   /// produced by [getNextArg].


### PR DESCRIPTION
## Summary
Two header sentences in serializable.dart still said `returns a [Future] of [ReturnType]` after #78 changed the signatures. Reword to match the actual contract.

## Test plan
- [x] flutter test — pass.
- [x] dart analyze --fatal-infos lib/ — clean.

Closes #94