### PR TITLE
test(mutation-backoff): drop unverified parenthetical from test name

### DIFF
--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -253,7 +253,7 @@ void main() {
   });
 
   group('MutationKey Backoff', () {
-    test('retries succeed when no backoff is provided (default behaviour preserved)', () async {
+    test('retries succeed when no backoff is provided', () async {
       final request = CreateUserRequest(name: 'Bo', email: 'bo@example.com');
       final user = User(id: 1, name: 'Bo', email: 'bo@example.com');
       var calls = 0;


### PR DESCRIPTION
## Summary
Rename test from 'retries succeed when no backoff is provided (default behaviour preserved)' to 'retries succeed when no backoff is provided'. The body never asserted the default-behaviour-preservation claim; that's covered separately.

## Test plan
- [x] flutter test — pass.

Closes #92