### PR TITLE
docs(arch): reword 'input side' framing to match the listed types

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 `typed_cached_query` is a **typed shim** over [`cached_query_flutter`](https://pub.dev/packages/cached_query_flutter) — not a self-contained façade.
 
-The library adds compile-time type safety on the **input** side of every query/mutation/infinite query (request payload, error type, return type, page-pointer type) but deliberately **returns the underlying `cached_query_flutter` types** (`Query<ReturnType>`, `Mutation<ReturnType, RequestType>`, `InfiniteQuery<ReturnType, RequestData>`, `QueryStatus<ReturnType>`, `MutationState<ReturnType>`, `InfiniteQueryStatus<ReturnType, RequestData>`) and re-exports those types — together with the configuration, observer, storage, and state-variant types they depend on — from the package barrel ([lib/typed_cached_query.dart](../lib/typed_cached_query.dart)).
+The library primarily adds compile-time type safety to the request/definition side of every query/mutation/infinite query (for example, the request payload, error type, return type, and page-pointer type used by the user-supplied callbacks) but deliberately **returns the underlying `cached_query_flutter` types** (`Query<ReturnType>`, `Mutation<ReturnType, RequestType>`, `InfiniteQuery<ReturnType, RequestData>`, `QueryStatus<ReturnType>`, `MutationState<ReturnType>`, `InfiniteQueryStatus<ReturnType, RequestData>`) and re-exports those types — together with the configuration, observer, storage, and state-variant types they depend on — from the package barrel ([lib/typed_cached_query.dart](../lib/typed_cached_query.dart)).
 
 Consumers therefore still need to learn the relevant parts of `cached_query_flutter` (state shapes, configuration knobs, lifecycle hooks). The wrapper is **not a substitute** for understanding the upstream package.
 


### PR DESCRIPTION
## Summary
Replace 'input side' with 'request/definition side ... used by the user-supplied callbacks'.

Closes #93