### PR TITLE
ci: ignore tag pushes on the push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    tags-ignore: ['**']
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
Add `tags-ignore: ['**']` so tag pushes don't fire the same workflow that already ran on the merge.

Closes #89