### PR TITLE
refactor(test-fixture): make CreateUserRequest.keyGenerator collision-resistant

### DIFF
--- a/test/data/models/create_user_request.dart
+++ b/test/data/models/create_user_request.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:cached_query_flutter/cached_query_flutter.dart';
 import 'package:typed_cached_query/src/errors/query_exception.dart';
 import 'package:typed_cached_query/src/models/serializable.dart';
@@ -17,7 +19,7 @@ class CreateUserRequest extends MutationSerializable<CreateUserRequest, User, Va
   MutationCache? get cache => _cache;
 
   @override
-  String get keyGenerator => 'create_user_${name}_$email';
+  String get keyGenerator => 'create_user_${jsonEncode(toJson())}';
 
   @override
   OnErrorResults<CreateUserRequest, User?> errorMapper(CreateUserRequest request, ValidationError error, User? fallback) {

--- a/test/data/models/key_determinism_test.dart
+++ b/test/data/models/key_determinism_test.dart
@@ -18,7 +18,16 @@ void main() {
       final a2 = CreateUserRequest(name: 'Alice', email: 'a@b.c', apiService: api);
 
       expect(a1.keyGenerator, a1.keyGenerator, reason: 'repeated reads must return the same key');
-      expect(a1.keyGenerator, a2.keyGenerator, reason: 'two requests with the same input must hash to the same key');
+      expect(a1.keyGenerator, a2.keyGenerator, reason: 'two requests with the same input must produce the same key');
+    });
+
+    test('CreateUserRequest.keyGenerator does not collide when fields contain underscores', () {
+      // Underscore-concatenated keys (the prior shape) collided when either field contained '_':
+      // (name: 'a_b', email: 'c') vs (name: 'a', email: 'b_c'). Using JSON encoding avoids this.
+      final api = _StubApiService();
+      final a = CreateUserRequest(name: 'a_b', email: 'c', apiService: api);
+      final b = CreateUserRequest(name: 'a', email: 'b_c', apiService: api);
+      expect(a.keyGenerator, isNot(b.keyGenerator));
     });
 
     test('UpdateUserRequest.keyGenerator is stable per instance', () {


### PR DESCRIPTION
## Summary
- Replace underscore concatenation with `jsonEncode(toJson())` to avoid collisions when fields contain '_'.
- Reword determinism test reason from 'hash' to 'produce'.
- Add a collision-resistance regression test for the previously-colliding pair.

## Test plan
- [x] flutter test — pass.

Closes #90