### PR TITLE
fix(mutation-key): wrap responseHandler parse errors as 400, not 500-retryable

### DIFF
--- a/lib/src/models/mutation_key.dart
+++ b/lib/src/models/mutation_key.dart
@@ -42,12 +42,13 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
       key: _valueKey,
       mutationFn: (requestParam) async {
         final maxAttempts = (retryAttempts ?? 0) + 1;
+        dynamic raw;
         for (var attempt = 1; attempt <= maxAttempts; attempt++) {
           try {
-            final raw = timeoutSeconds != null
+            raw = timeoutSeconds != null
                 ? await request.mutationFn().timeout(Duration(seconds: timeoutSeconds))
                 : await request.mutationFn();
-            return request.responseHandler(raw);
+            break;
           } catch (e) {
             if (e is TimeoutException && capturedOnTimeout != null) rethrow;
             if (e is! ErrorType) {
@@ -61,9 +62,14 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
             await Future<void>.delayed(backoffFn(attempt));
           }
         }
-        // Unreachable: the loop body always exits via `return` or `rethrow` on the final attempt.
-        // Dart's flow analysis does not see this, so a terminator is required.
-        throw StateError('unreachable: mutation retry loop completed without returning or throwing');
+        // responseHandler runs OUTSIDE the retry try/catch so a parsing failure surfaces as a
+        // 400 MutationException (same shape as QueryKey/InfiniteQueryKey) and is never retried —
+        // a malformed response is not a transient ErrorType.
+        try {
+          return request.responseHandler(raw);
+        } catch (e) {
+          throw MutationException('parsing the response of type ${raw.runtimeType} to $ReturnType failed: ${e.toString()}', 400);
+        }
       },
       onError: (requestParam, error, fallback) {
         if (error is MutationException || error is ArgumentError) {

--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -60,6 +60,33 @@ abstract class MockApiService {
 
 @GenerateMocks([MockApiService])
 // Test Mutation Implementations
+class _ParseFailingMutation extends MutationSerializable<_ParseFailingMutation, User, ValidationError> {
+  final CreateUserRequest request;
+  final MockApiService apiService;
+  final MutationCache? _cache;
+
+  _ParseFailingMutation({required this.request, required this.apiService, MutationCache? cache}) : _cache = cache;
+
+  @override
+  String get keyGenerator => 'parse_failing_${request.name}';
+
+  @override
+  OnErrorResults<_ParseFailingMutation, User?> errorMapper(_ParseFailingMutation request, ValidationError error, User? fallback) {
+    return OnErrorResults(request: request, error: MutationException(error.message, 400), fallback: fallback);
+  }
+
+  @override
+  User responseHandler(dynamic response) {
+    throw const FormatException('responseHandler intentionally failed');
+  }
+
+  @override
+  Future<dynamic> mutationFn() => apiService.createUser(request);
+
+  @override
+  MutationCache? get cache => _cache;
+}
+
 class CreateUserMutation extends MutationSerializable<CreateUserMutation, User, ValidationError> {
   final CreateUserRequest request;
   final MockApiService apiService;
@@ -313,6 +340,36 @@ void main() {
     test('defaultMutationBackoff returns 100 ms × attempt', () {
       expect(defaultMutationBackoff(1), const Duration(milliseconds: 100));
       expect(defaultMutationBackoff(3), const Duration(milliseconds: 300));
+    });
+  });
+
+  group('MutationKey responseHandler error wrapping', () {
+    test('responseHandler exception is wrapped as MutationException(400) and not retried', () async {
+      final request = CreateUserRequest(name: 'Bo', email: 'bo@example.com');
+      var attempts = 0;
+      when(mockApiService.createUser(request)).thenAnswer((_) async {
+        attempts += 1;
+        return User(id: 1, name: 'Bo', email: 'bo@example.com');
+      });
+
+      // Subclass the existing fixture so its responseHandler always throws.
+      final mutation = _ParseFailingMutation(request: request, apiService: mockApiService, cache: mutationCache);
+
+      Object? thrown;
+      try {
+        await MutationKey<_ParseFailingMutation, User, ValidationError>(mutation).mutate(
+          retryAttempts: 3,
+          shouldRetry: (_) => true,
+        );
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown, isA<MutationException>());
+      expect((thrown as MutationException).statusCode, 400, reason: 'parsing errors must surface as a 400 — same shape as QueryKey/InfiniteQueryKey');
+      expect(thrown.message, contains('parsing the response'));
+      // Parse failures are NOT retryable — only ErrorType failures are.
+      expect(attempts, 1, reason: 'a parse failure must NOT be retried, even when retryAttempts/shouldRetry are set');
     });
   });
 


### PR DESCRIPTION
## Summary
Move `responseHandler` invocation outside the retry try/catch. Parse failures now wrap as `MutationException(400)` with the same 'parsing the response of type X to Y failed' message used by QueryKey/InfiniteQueryKey, and are never retried.

## Test plan
- [x] RED test added: a fixture whose responseHandler throws lands as a 400 `MutationException` and is invoked exactly once even with `retryAttempts: 3, shouldRetry: (_) => true`.
- [x] flutter test — 129/129 pass.
- [x] dart analyze --fatal-infos lib/ — clean.

Closes #86