### PR TITLE
fix(error-getters): restore state.isError guard

### DIFF
--- a/lib/src/models/infinite_query_key.dart
+++ b/lib/src/models/infinite_query_key.dart
@@ -106,6 +106,7 @@ class InfiniteQueryKey<RequestType extends InfiniteQuerySerializable<ReturnType,
 
   QueryException? get error {
     if (_getInfiniteQuery == null) return null;
+    if (!_getInfiniteQuery!.state.isError) return null;
     final stateError = _getInfiniteQuery!.state.error;
     if (stateError == null) return null;
     if (stateError is QueryException) return stateError;

--- a/lib/src/models/query_key.dart
+++ b/lib/src/models/query_key.dart
@@ -93,6 +93,7 @@ class QueryKey<RequestType extends QuerySerializable<ReturnType, ErrorType>, Ret
   bool get isError => _getQuery != null && _getQuery!.state.isError;
   QueryException? get error {
     if (_getQuery == null) return null;
+    if (!_getQuery!.state.isError) return null;
     final stateError = _getQuery!.state.error;
     if (stateError == null) return null;
     if (stateError is QueryException) return stateError;

--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -279,6 +279,36 @@ void main() {
     });
   });
 
+  group('MutationKey error getter', () {
+    test('returns null when state is not in error', () async {
+      final request = CreateUserRequest(name: 'OK', email: 'ok@example.com');
+      final user = User(id: 1, name: 'OK', email: 'ok@example.com');
+      when(mockApiService.createUser(request)).thenAnswer((_) async => user);
+
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      final mutationKey = MutationKey(mutation);
+      await mutationKey.mutate();
+
+      expect(mutationKey.isError, isFalse);
+      expect(mutationKey.error, isNull, reason: 'error must mirror isError — never returns a value when isError is false');
+    });
+
+    test('maps a stored ErrorType via errorMapper', () async {
+      final request = CreateUserRequest(name: 'Bad', email: 'bad@example.com');
+      when(mockApiService.createUser(request)).thenThrow(ValidationError('email', 'taken'));
+
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      final mutationKey = MutationKey(mutation);
+      try {
+        await mutationKey.mutate();
+      } catch (_) {/* expected */}
+
+      expect(mutationKey.isError, isTrue);
+      expect(mutationKey.error, isA<MutationException>());
+      expect(mutationKey.error!.message, contains('Validation failed on email'));
+    });
+  });
+
   group('MutationKey Backoff', () {
     test('retries succeed when no backoff is provided', () async {
       final request = CreateUserRequest(name: 'Bo', email: 'bo@example.com');

--- a/test/src/models/query_key_test.dart
+++ b/test/src/models/query_key_test.dart
@@ -292,6 +292,46 @@ void main() {
     });
   });
 
+  group('QueryKey error getter', () {
+    test('returns null when state is not in error', () async {
+      final user = User(id: 1, name: 'A', email: 'a@b.c');
+      when(mockApiService.getUser(1)).thenAnswer((_) async => user);
+
+      final request = GetUserQuery(userId: 1, apiService: mockApiService, localCache: cachedQuery);
+      final queryKey = QueryKey(request);
+      await queryKey.query().fetch();
+
+      expect(queryKey.isError, isFalse);
+      expect(queryKey.error, isNull, reason: 'error must mirror isError — never returns a value when isError is false');
+    });
+
+    test('passes through a stored QueryException unchanged', () async {
+      // Trigger an unhandled exception so the underlying state stores a QueryException.
+      when(mockApiService.getUser(2)).thenAnswer((_) async => throw FormatException('boom'));
+
+      final request = GetUserQuery(userId: 2, apiService: mockApiService, localCache: cachedQuery);
+      final queryKey = QueryKey(request);
+      await queryKey.query().fetch();
+
+      expect(queryKey.isError, isTrue);
+      expect(queryKey.error, isA<QueryException>());
+    });
+
+    test('maps a stored ErrorType via errorMapper', () async {
+      when(mockApiService.getUser(3)).thenThrow(ApiError('x', 503));
+
+      final request = GetUserQuery(userId: 3, apiService: mockApiService, localCache: cachedQuery);
+      final queryKey = QueryKey(request);
+      try {
+        await queryKey.query().fetch();
+      } catch (_) {/* expected */}
+
+      expect(queryKey.isError, isTrue);
+      expect(queryKey.error, isA<QueryException>());
+      expect(queryKey.error!.message, contains('API Error: x'));
+    });
+  });
+
   group('QueryKey Data Management', () {
     test('should update data correctly', () async {
       final user = User(id: 123, name: 'John Doe', email: 'john@example.com');


### PR DESCRIPTION
## Summary
- Restore `if (!state.isError) return null;` in `QueryKey.error` and `InfiniteQueryKey.error`.
- MutationKey.error already gates on `state is! MutationError`, no code change there.
- Add error-getter regression tests for QueryKey + MutationKey.

## Test plan
- [x] flutter test — 134/134 pass.
- [x] dart analyze --fatal-infos lib/ — clean.

Closes #84