### PR TITLE
test(infinite-query): assert via wrapper contract instead of raw state.error

### DIFF
--- a/test/src/models/infinite_query_key_test.dart
+++ b/test/src/models/infinite_query_key_test.dart
@@ -413,10 +413,12 @@ void main() {
         await query.getNextPage();
       } catch (_) {/* expected to surface */}
 
-      expect(query.state.error, isNotNull, reason: 'A throwing getNextArg must surface as an error state, not as silent end-of-pagination');
-      expect(infiniteQueryKey.isError, isTrue, reason: 'The query handle must report isError after a getNextArg failure');
+      expect(infiniteQueryKey.isError, isTrue, reason: 'The wrapper must report isError after a getNextArg failure');
       expect(query.state, isA<InfiniteQueryError<PagedResponse, PageArgs>>(), reason: 'state must be InfiniteQueryError, not InfiniteQuerySuccess(hasReachedMax: true)');
-      expect(query.state.error, isA<ApiError>(), reason: 'ErrorType throws are stored as the original ErrorType in state.error');
+      // Assert the wrapper contract (errorMapper-translated QueryException) rather than the raw
+      // cached_query state.error storage shape — that decouples the test from upstream storage choices.
+      expect(infiniteQueryKey.error, isA<QueryException>(), reason: 'ErrorType throws are exposed via the wrapper as QueryException');
+      expect(infiniteQueryKey.error!.message, contains('boom'), reason: 'wrapper must map ErrorType through errorMapper');
     });
 
     test('getNextArg throw of unknown error surfaces an error state', () async {
@@ -429,11 +431,11 @@ void main() {
         await query.getNextPage();
       } catch (_) {/* expected */}
 
-      expect(query.state.error, isNotNull);
-      expect(query.state.error, isA<QueryException>(), reason: 'unknown-type errors are wrapped in QueryException by the getNextArg wrapper');
-      expect((query.state.error as QueryException).message, contains('getNextArg'));
       expect(infiniteQueryKey.isError, isTrue);
       expect(query.state, isA<InfiniteQueryError<PagedResponse, PageArgs>>());
+      // Assert via the wrapper contract — the public surface that consumers actually read.
+      expect(infiniteQueryKey.error, isA<QueryException>(), reason: 'unknown-type errors are exposed via the wrapper as QueryException');
+      expect(infiniteQueryKey.error!.message, contains('getNextArg'));
     });
 
     test('error getter does not throw when state.error is a QueryException (unknown-type path)', () async {


### PR DESCRIPTION
## Summary
Replace `query.state.error is ApiError` / `query.state.error is QueryException` assertions with `infiniteQueryKey.error` assertions. Tests now exercise the public surface consumers depend on, not cached_query's internal storage shape.

## Test plan
- [x] flutter test — pass.

Closes #91