### PR TITLE
test(mutation+infinite-key): make responseHandler-wiring tests observable

### DIFF
--- a/test/src/models/infinite_query_key_test.dart
+++ b/test/src/models/infinite_query_key_test.dart
@@ -514,4 +514,56 @@ void main() {
       expect(nextArg.limit, 10);
     });
   });
+
+  group('InfiniteQueryKey responseHandler wiring', () {
+    test('queryFn raw page is passed through responseHandler before reaching state', () async {
+      // Fixture's queryFn returns a Map; responseHandler builds a PagedResponse with a sentinel
+      // suffix on the user name. If the wrapper bypassed responseHandler, state.data.pages would
+      // contain a Map (or fail to construct), and the assertion would fail.
+      final request = _MapInfiniteQuery(localCache: cachedQuery);
+      final infiniteQueryKey = InfiniteQueryKey(request);
+      final query = infiniteQueryKey.query();
+
+      await query.fetch();
+
+      final pages = query.state.data?.pages ?? const [];
+      expect(pages, isNotEmpty);
+      expect(pages.first, isA<PagedResponse>(), reason: 'state.data must contain the responseHandler-produced PagedResponse, not the raw Map from queryFn');
+      expect(pages.first.users.first.name, endsWith('-via-responseHandler'));
+    });
+  });
+}
+
+/// Fixture for the InfiniteQuery responseHandler-wiring test.
+class _MapInfiniteQuery extends InfiniteQuerySerializable<PagedResponse, PageArgs, ApiError> {
+  final CachedQuery localCache;
+  _MapInfiniteQuery({required this.localCache});
+
+  @override
+  String get keyGenerator => 'map_infinite_query';
+  @override
+  QueryException errorMapper(ApiError error) => QueryException(error.message, error.code);
+  @override
+  PagedResponse responseHandler(dynamic response) {
+    final map = response as Map<String, dynamic>;
+    final users = (map['users'] as List)
+        .map((u) {
+          final m = u as Map<String, dynamic>;
+          return User(id: m['id'] as int, name: '${m['name']}-via-responseHandler', email: m['email'] as String);
+        })
+        .toList();
+    return PagedResponse(users: users, page: map['page'] as int, totalPages: map['totalPages'] as int, hasNext: map['hasNext'] as bool);
+  }
+  @override
+  Future<dynamic> queryFn(PageArgs arg) async => {
+        'users': [{'id': 1, 'name': 'Raw', 'email': 'raw@example.com'}],
+        'page': arg.page,
+        'totalPages': 1,
+        'hasNext': false,
+      };
+  @override
+  CachedQuery get cache => localCache;
+  @override
+  PageArgs? getNextArg(InfiniteQueryData<PagedResponse, PageArgs>? data) =>
+      (data == null || data.pages.isEmpty) ? PageArgs(page: 1, limit: 10) : null;
 }

--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -405,17 +405,43 @@ void main() {
 
   group('MutationKey responseHandler wiring', () {
     test('mutationFn raw output is passed through responseHandler before reaching the caller', () async {
-      final request = CreateUserRequest(name: 'Bo', email: 'bo@example.com');
-      // mutationFn returns a User. responseHandler in this fixture is `response as User`, so the
-      // wiring is observable indirectly: the test verifies the result comes back as the
-      // responseHandler-produced value (identical reference) rather than something from a bypass path.
-      final user = User(id: 99, name: 'Bo', email: 'bo@example.com');
-      when(mockApiService.createUser(request)).thenAnswer((_) async => user);
-
-      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      // Use a fixture whose mutationFn returns a raw Map and whose responseHandler reconstructs
+      // a User with a sentinel suffix. If responseHandler were bypassed, result.data would be the
+      // raw Map (not a User) and the assertions would fail.
+      final mutation = _MapMutation(returnRaw: {'id': 7, 'name': 'Raw', 'email': 'raw@example.com'}, cache: mutationCache);
       final result = await MutationKey(mutation).mutate();
 
-      expect(identical(result.data, user), isTrue, reason: 'mutate result must be the value returned by responseHandler');
+      expect(result.data, isA<User>(), reason: 'mutate result must be the User produced by responseHandler, not the raw Map from mutationFn');
+      expect(result.data!.name, endsWith('-via-responseHandler'), reason: 'sentinel suffix proves responseHandler ran');
     });
   });
+}
+
+/// Fixture for the responseHandler-wiring test: raw mutationFn returns a Map and responseHandler
+/// reconstructs a User with a sentinel suffix so the wiring is *observable* — bypassing
+/// responseHandler would leave result.data as the raw Map.
+class _MapMutation extends MutationSerializable<_MapMutation, User, ValidationError> {
+  final Map<String, dynamic> returnRaw;
+  final MutationCache? _cache;
+
+  _MapMutation({required this.returnRaw, MutationCache? cache}) : _cache = cache;
+
+  @override
+  String get keyGenerator => 'map_mutation';
+
+  @override
+  OnErrorResults<_MapMutation, User?> errorMapper(_MapMutation request, ValidationError error, User? fallback) =>
+      OnErrorResults(request: request, error: MutationException(error.message, 400), fallback: fallback);
+
+  @override
+  User responseHandler(dynamic response) {
+    final map = response as Map<String, dynamic>;
+    return User(id: map['id'] as int, name: '${map['name']}-via-responseHandler', email: map['email'] as String);
+  }
+
+  @override
+  Future<dynamic> mutationFn() async => returnRaw;
+
+  @override
+  MutationCache? get cache => _cache;
 }


### PR DESCRIPTION
## Summary
- Replace identity-cast responseHandlers with fixtures whose responseHandler tags the produced value with a sentinel suffix.
- Add an InfiniteQueryKey wiring test.
- Both tests fail if responseHandler is bypassed in their respective pipelines.

## Test plan
- [x] flutter test — 136/136 pass.

Closes #87