### PR TITLE
test(error-getters): close coverage gaps flagged on PR #102

### DIFF
--- a/test/src/models/infinite_query_key_test.dart
+++ b/test/src/models/infinite_query_key_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cached_query_flutter/cached_query_flutter.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -510,42 +512,57 @@ void main() {
     });
 
     test('wraps an unknown stored error in a fallback QueryException(500)', () async {
-      when(mockApiService.getUsersPage(any)).thenAnswer((_) async {
-        await Future<void>.delayed(const Duration(milliseconds: 1));
-        throw Exception('mystery failure');
-      });
-
+      // The wrapper's queryFn closure pre-wraps non-ErrorType throws as QueryException — so a
+      // wrapper-driven fetch never reaches the getter's `Unhandled error:` fallback branch.
+      // Bypass the wrapper by seeding the cache with a raw InfiniteQuery under the same key/cache.
       final request = GetUsersInfiniteQuery(apiService: mockApiService, localCache: cachedQuery);
       final infiniteQueryKey = InfiniteQueryKey(request);
-      await infiniteQueryKey.query().fetch();
+
+      final rawInfiniteQuery = InfiniteQuery<PagedResponse, PageArgs>(
+        cache: cachedQuery,
+        key: infiniteQueryKey.rawKey,
+        queryFn: (_) async => throw Exception('mystery failure'),
+        getNextArg: (_) => PageArgs(page: 1, limit: 10),
+        config: const QueryConfig(staleDuration: Duration.zero, ignoreCacheDuration: true),
+      );
+      await rawInfiniteQuery.fetch();
 
       expect(infiniteQueryKey.isError, isTrue);
       final err = infiniteQueryKey.error;
       expect(err, isA<QueryException>());
       expect(err!.statusCode, 500);
+      expect(err.message, contains('Unhandled error:'));
+      expect(err.message, contains('mystery failure'));
     });
 
-    test('returns null after a successful fetch following a prior failure (regression: stale-error guard)', () async {
+    test('returns null mid-refetch even if state.error retains the previous failure (regression: stale-error guard)', () async {
+      // First fetch: error.
       when(mockApiService.getUsersPage(any)).thenThrow(ApiError('first', 503));
-
       final request = GetUsersInfiniteQuery(apiService: mockApiService, localCache: cachedQuery);
       final infiniteQueryKey = InfiniteQueryKey(request);
       await infiniteQueryKey.query().fetch();
       expect(infiniteQueryKey.isError, isTrue);
 
-      // Flip mock to success and refetch on the same key.
+      // Second fetch: slow success controlled by a Completer so we can observe state DURING loading.
       reset(mockApiService);
-      final pageResponse = PagedResponse(
+      final completer = Completer<PagedResponse>();
+      when(mockApiService.getUsersPage(any)).thenAnswer((_) => completer.future);
+
+      final futureRefetch = infiniteQueryKey.query().fetch();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(infiniteQueryKey.isError, isFalse, reason: 'mid-refetch the wrapper must report not-error');
+      expect(infiniteQueryKey.error, isNull, reason: 'mid-refetch .error must mirror isError and be null');
+
+      completer.complete(PagedResponse(
         users: [User(id: 1, name: 'Recovered', email: 'r@b.c')],
         page: 1,
         totalPages: 1,
         hasNext: false,
-      );
-      when(mockApiService.getUsersPage(any)).thenAnswer((_) async => pageResponse);
-      await infiniteQueryKey.query().fetch();
-
-      expect(infiniteQueryKey.isError, isFalse, reason: 'after a successful refetch the wrapper must report not-error');
-      expect(infiniteQueryKey.error, isNull, reason: 'after a successful refetch .error must mirror isError and be null');
+      ));
+      await futureRefetch;
+      expect(infiniteQueryKey.isError, isFalse);
+      expect(infiniteQueryKey.error, isNull);
     });
   });
 

--- a/test/src/models/infinite_query_key_test.dart
+++ b/test/src/models/infinite_query_key_test.dart
@@ -477,6 +477,78 @@ void main() {
     });
   });
 
+  group('InfiniteQueryKey error getter', () {
+    test('returns null when state is not in error', () async {
+      final pageResponse = PagedResponse(
+        users: [User(id: 1, name: 'John', email: 'john@example.com')],
+        page: 1,
+        totalPages: 1,
+        hasNext: false,
+      );
+      when(mockApiService.getUsersPage(any)).thenAnswer((_) async => pageResponse);
+
+      final request = GetUsersInfiniteQuery(apiService: mockApiService, localCache: cachedQuery);
+      final infiniteQueryKey = InfiniteQueryKey(request);
+      await infiniteQueryKey.query().fetch();
+
+      expect(infiniteQueryKey.isError, isFalse);
+      expect(infiniteQueryKey.error, isNull, reason: 'error must mirror isError — never returns a value when isError is false');
+    });
+
+    test('maps a stored ErrorType via errorMapper', () async {
+      when(mockApiService.getUsersPage(any)).thenThrow(ApiError('boom', 503));
+
+      final request = GetUsersInfiniteQuery(apiService: mockApiService, localCache: cachedQuery);
+      final infiniteQueryKey = InfiniteQueryKey(request);
+      await infiniteQueryKey.query().fetch();
+
+      expect(infiniteQueryKey.isError, isTrue);
+      final err = infiniteQueryKey.error;
+      expect(err, isA<QueryException>());
+      expect(err!.message, contains('API Error: boom'));
+      expect(err.statusCode, 503);
+    });
+
+    test('wraps an unknown stored error in a fallback QueryException(500)', () async {
+      when(mockApiService.getUsersPage(any)).thenAnswer((_) async {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+        throw Exception('mystery failure');
+      });
+
+      final request = GetUsersInfiniteQuery(apiService: mockApiService, localCache: cachedQuery);
+      final infiniteQueryKey = InfiniteQueryKey(request);
+      await infiniteQueryKey.query().fetch();
+
+      expect(infiniteQueryKey.isError, isTrue);
+      final err = infiniteQueryKey.error;
+      expect(err, isA<QueryException>());
+      expect(err!.statusCode, 500);
+    });
+
+    test('returns null after a successful fetch following a prior failure (regression: stale-error guard)', () async {
+      when(mockApiService.getUsersPage(any)).thenThrow(ApiError('first', 503));
+
+      final request = GetUsersInfiniteQuery(apiService: mockApiService, localCache: cachedQuery);
+      final infiniteQueryKey = InfiniteQueryKey(request);
+      await infiniteQueryKey.query().fetch();
+      expect(infiniteQueryKey.isError, isTrue);
+
+      // Flip mock to success and refetch on the same key.
+      reset(mockApiService);
+      final pageResponse = PagedResponse(
+        users: [User(id: 1, name: 'Recovered', email: 'r@b.c')],
+        page: 1,
+        totalPages: 1,
+        hasNext: false,
+      );
+      when(mockApiService.getUsersPage(any)).thenAnswer((_) async => pageResponse);
+      await infiniteQueryKey.query().fetch();
+
+      expect(infiniteQueryKey.isError, isFalse, reason: 'after a successful refetch the wrapper must report not-error');
+      expect(infiniteQueryKey.error, isNull, reason: 'after a successful refetch .error must mirror isError and be null');
+    });
+  });
+
   group('InfiniteQueryKey Pagination Logic', () {
     test('should correctly determine when max is reached', () async {
       // Last page response

--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -299,13 +299,41 @@ void main() {
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
       final mutationKey = MutationKey(mutation);
-      try {
-        await mutationKey.mutate();
-      } catch (_) {/* expected */}
+      // mutate does NOT throw for ErrorType — it maps via errorMapper and surfaces via state.
+      await mutationKey.mutate();
 
       expect(mutationKey.isError, isTrue);
-      expect(mutationKey.error, isA<MutationException>());
-      expect(mutationKey.error!.message, contains('Validation failed on email'));
+      final err = mutationKey.error;
+      expect(err, isA<MutationException>());
+      expect(err!.message, contains('Validation failed on email'));
+    });
+
+    // Note: the MutationKey 'unknown stored error' fallback branch (status 500 'Unhandled error:'
+    // path) is intentionally NOT covered here. When mutationFn throws a non-ErrorType, the wrapper
+    // throws MutationException internally and cached_query leaves the mutation in an in-flight
+    // (isMutating=true) state rather than transitioning to MutationError, so .error returns null
+    // regardless of getter implementation. The analogous fallback in QueryKey.error and
+    // InfiniteQueryKey.error IS covered by their respective test groups, which lock in the
+    // shared branch logic.
+
+    test('returns null after a successful mutate following a prior failure (regression: stale-error guard)', () async {
+      // Pre-#102: state.error could remain non-null on a non-error state, so .error returned a
+      // value while .isError was false. Run a failing mutate, then a successful one on the same
+      // mutation, and assert .error mirrors isError and is null.
+      final request = CreateUserRequest(name: 'Flip', email: 'flip@example.com');
+      when(mockApiService.createUser(request)).thenThrow(ValidationError('email', 'taken'));
+
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      final mutationKey = MutationKey(mutation);
+      await mutationKey.mutate();
+      expect(mutationKey.isError, isTrue);
+
+      reset(mockApiService);
+      when(mockApiService.createUser(request)).thenAnswer((_) async => User(id: 9, name: 'Flip', email: 'flip@example.com'));
+      await mutationKey.mutate();
+
+      expect(mutationKey.isError, isFalse, reason: 'after a successful mutate the wrapper must report not-error');
+      expect(mutationKey.error, isNull, reason: 'after a successful mutate .error must mirror isError and be null');
     });
   });
 

--- a/test/src/models/query_key_test.dart
+++ b/test/src/models/query_key_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cached_query_flutter/cached_query_flutter.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -336,42 +338,55 @@ void main() {
     });
 
     test('wraps an unknown stored error in a fallback QueryException(500)', () async {
-      // Force a non-ErrorType, non-QueryException into state.error: a query that fails AFTER an
-      // await with a plain Exception. _wrappedQueryFn wraps non-ErrorType errors as QueryException
-      // with status 500 'An unhandled exception has taken place ...'.
-      when(mockApiService.getUser(5)).thenAnswer((_) async {
-        await Future<void>.delayed(const Duration(milliseconds: 1));
-        throw Exception('mystery failure');
-      });
-
+      // The wrapper's _wrappedQueryFn pre-wraps non-ErrorType throws as QueryException — so a
+      // wrapper-driven fetch never reaches the getter's `Unhandled error:` fallback branch.
+      // Bypass the wrapper by seeding the cache with a raw Query under the same key/cache; that
+      // stores a plain Exception in state.error, which exercises the fallback branch.
       final request = GetUserQuery(userId: 5, apiService: mockApiService, localCache: cachedQuery);
       final queryKey = QueryKey(request);
-      await queryKey.query().fetch();
+
+      final rawQuery = Query<User>(
+        cache: cachedQuery,
+        key: queryKey.rawKey,
+        queryFn: () async => throw Exception('mystery failure'),
+        config: const QueryConfig(staleDuration: Duration.zero, ignoreCacheDuration: true),
+      );
+      await rawQuery.fetch();
 
       expect(queryKey.isError, isTrue);
       final err = queryKey.error;
       expect(err, isA<QueryException>());
       expect(err!.statusCode, 500);
+      expect(err.message, contains('Unhandled error:'));
+      expect(err.message, contains('mystery failure'));
     });
 
-    test('returns null after a successful fetch following a prior failure (regression: stale-error guard)', () async {
-      // Pre-#102: state.error could remain non-null on a non-error state, so .error returned a
-      // value while .isError was false. This test fetches an error first, then a success on the
-      // SAME key, and asserts the wrapper reflects the new (non-error) state.
+    test('returns null mid-refetch even if state.error retains the previous failure (regression: stale-error guard)', () async {
+      // First fetch: error.
       when(mockApiService.getUser(6)).thenThrow(ApiError('first', 503));
-
       final request = GetUserQuery(userId: 6, apiService: mockApiService, localCache: cachedQuery);
       final queryKey = QueryKey(request);
       await queryKey.query().fetch();
       expect(queryKey.isError, isTrue);
 
-      // Now flip the mock to succeed and trigger a refetch on the same key.
+      // Second fetch: slow success controlled by a Completer so we can observe state DURING loading.
       reset(mockApiService);
-      when(mockApiService.getUser(6)).thenAnswer((_) async => User(id: 6, name: 'OK', email: 'o@b.c'));
-      await queryKey.query().fetch();
+      final completer = Completer<User>();
+      when(mockApiService.getUser(6)).thenAnswer((_) => completer.future);
 
-      expect(queryKey.isError, isFalse, reason: 'after a successful refetch the wrapper must report not-error');
-      expect(queryKey.error, isNull, reason: 'after a successful refetch .error must mirror isError and be null');
+      final futureRefetch = queryKey.query().fetch();
+      // Yield once so the loading state transition lands.
+      await Future<void>.delayed(Duration.zero);
+
+      // The reported regression in #102: state.error could retain the previous failure during a
+      // loading state. The isError guard restored in #102 is what makes this assertion pass.
+      expect(queryKey.isError, isFalse, reason: 'mid-refetch the wrapper must report not-error');
+      expect(queryKey.error, isNull, reason: 'mid-refetch .error must mirror isError and be null');
+
+      completer.complete(User(id: 6, name: 'OK', email: 'o@b.c'));
+      await futureRefetch;
+      expect(queryKey.isError, isFalse, reason: 'and after the refetch settles, still not-error');
+      expect(queryKey.error, isNull);
     });
   });
 

--- a/test/src/models/query_key_test.dart
+++ b/test/src/models/query_key_test.dart
@@ -311,10 +311,14 @@ void main() {
 
       final request = GetUserQuery(userId: 2, apiService: mockApiService, localCache: cachedQuery);
       final queryKey = QueryKey(request);
-      await queryKey.query().fetch();
+      final query = queryKey.query();
+      await query.fetch();
 
       expect(queryKey.isError, isTrue);
+      // Identity check — the getter must return the SAME QueryException instance from state,
+      // not a wrapped or recreated one.
       expect(queryKey.error, isA<QueryException>());
+      expect(queryKey.error, same(query.state.error));
     });
 
     test('maps a stored ErrorType via errorMapper', () async {
@@ -322,13 +326,52 @@ void main() {
 
       final request = GetUserQuery(userId: 3, apiService: mockApiService, localCache: cachedQuery);
       final queryKey = QueryKey(request);
-      try {
-        await queryKey.query().fetch();
-      } catch (_) {/* expected */}
+      await queryKey.query().fetch();
 
       expect(queryKey.isError, isTrue);
-      expect(queryKey.error, isA<QueryException>());
-      expect(queryKey.error!.message, contains('API Error: x'));
+      final err = queryKey.error;
+      expect(err, isA<QueryException>());
+      expect(err!.message, contains('API Error: x'));
+      expect(err.statusCode, 503);
+    });
+
+    test('wraps an unknown stored error in a fallback QueryException(500)', () async {
+      // Force a non-ErrorType, non-QueryException into state.error: a query that fails AFTER an
+      // await with a plain Exception. _wrappedQueryFn wraps non-ErrorType errors as QueryException
+      // with status 500 'An unhandled exception has taken place ...'.
+      when(mockApiService.getUser(5)).thenAnswer((_) async {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+        throw Exception('mystery failure');
+      });
+
+      final request = GetUserQuery(userId: 5, apiService: mockApiService, localCache: cachedQuery);
+      final queryKey = QueryKey(request);
+      await queryKey.query().fetch();
+
+      expect(queryKey.isError, isTrue);
+      final err = queryKey.error;
+      expect(err, isA<QueryException>());
+      expect(err!.statusCode, 500);
+    });
+
+    test('returns null after a successful fetch following a prior failure (regression: stale-error guard)', () async {
+      // Pre-#102: state.error could remain non-null on a non-error state, so .error returned a
+      // value while .isError was false. This test fetches an error first, then a success on the
+      // SAME key, and asserts the wrapper reflects the new (non-error) state.
+      when(mockApiService.getUser(6)).thenThrow(ApiError('first', 503));
+
+      final request = GetUserQuery(userId: 6, apiService: mockApiService, localCache: cachedQuery);
+      final queryKey = QueryKey(request);
+      await queryKey.query().fetch();
+      expect(queryKey.isError, isTrue);
+
+      // Now flip the mock to succeed and trigger a refetch on the same key.
+      reset(mockApiService);
+      when(mockApiService.getUser(6)).thenAnswer((_) async => User(id: 6, name: 'OK', email: 'o@b.c'));
+      await queryKey.query().fetch();
+
+      expect(queryKey.isError, isFalse, reason: 'after a successful refetch the wrapper must report not-error');
+      expect(queryKey.error, isNull, reason: 'after a successful refetch .error must mirror isError and be null');
     });
   });
 


### PR DESCRIPTION
## Summary
Strengthens error-getter coverage across all three Key types per PR #102's review:
- QueryKey: pass-through identity check, unknown-error fallback, stale-error regression.
- MutationKey: dropped misleading try/catch, added stale-error regression.
- InfiniteQueryKey: whole new error-getter test group (none existed previously).

## Test plan
- [x] flutter test — 143/143 pass.
- [x] dart analyze --fatal-infos lib/ — clean.

Closes #107