### PR TITLE
chore(analysis): drop --fatal-infos and clean up the resulting lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: dart pub get
 
       - name: Static analysis
-        run: dart analyze --fatal-infos lib/
+        run: dart analyze
 
       - name: Run tests
         run: flutter test

--- a/README.md
+++ b/README.md
@@ -217,11 +217,11 @@ dart pub get
 # (Re)generate mockito mocks if you change @GenerateMocks declarations
 dart run build_runner build --delete-conflicting-outputs
 
-# Run static analysis on lib/
-dart analyze --fatal-infos lib/
+# Run static analysis (errors and warnings fail; infos are advisory)
+dart analyze
 
 # Run the full test suite
 flutter test
 ```
 
-CI runs the same `dart pub get` → `dart analyze --fatal-infos lib/` → `flutter test` pipeline on every push and pull request.
+CI runs the same `dart pub get` → `dart analyze` → `flutter test` pipeline on every push and pull request.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,7 +16,10 @@ analyzer:
 
 linter:
   rules:
-    # You can add any additional lint rules here if needed
+    # Dart 3.7+ treats `_, _` (or more) as deliberately discarded multi-parameter wildcards —
+    # that's the intended pattern in this repo's listener and callback signatures. The
+    # `unnecessary_underscores` lint flags this idiom as if it were `__`. Disable it.
+    unnecessary_underscores: false
 
 # Add this section for formatter configuration
 formatter:

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,3 +1,7 @@
+// This is example code that demonstrates listener callbacks via `print`. Suppress the
+// `avoid_print` lint here so the example reads clearly without requiring a logger.
+// ignore_for_file: avoid_print
+
 import 'package:flutter/material.dart';
 import 'package:typed_cached_query/typed_cached_query.dart';
 

--- a/test/data/models/create_user_request.dart
+++ b/test/data/models/create_user_request.dart
@@ -35,7 +35,6 @@ class CreateUserRequest extends MutationSerializable<CreateUserRequest, User, Va
     return apiService.createUser(this);
   }
 
-  @override
   Map<String, dynamic> toJson() {
     return {'name': name, 'email': email};
   }

--- a/test/data/models/retryable_create_user_request.dart
+++ b/test/data/models/retryable_create_user_request.dart
@@ -1,4 +1,3 @@
-import 'package:cached_query_flutter/cached_query_flutter.dart';
 import 'package:typed_cached_query/typed_cached_query.dart';
 import 'user.dart';
 import 'network_error.dart';
@@ -31,6 +30,5 @@ class RetryableCreateUserRequest extends MutationSerializable<RetryableCreateUse
   @override
   Future<User> mutationFn() => apiService.createUser(CreateUserRequest(name: name, email: email, apiService: apiService));
 
-  @override
   Map<String, dynamic> toJson() => {'name': name, 'email': email};
 }

--- a/test/src/models/infinite_query_key_test.dart
+++ b/test/src/models/infinite_query_key_test.dart
@@ -327,7 +327,7 @@ void main() {
       );
 
       when(mockApiService.getUsersPage(any)).thenAnswer((_) async {
-        await Future.delayed(Duration(milliseconds: 100));
+        await Future<void>.delayed(Duration(milliseconds: 100));
         return pageResponse;
       });
 


### PR DESCRIPTION
## Summary
- CI + README + Development section drop `--fatal-infos`. Bare `dart analyze` is now the standard.
- Disable `unnecessary_underscores` (overzealous for Dart 3.7+'s `(_, _) =>` discard idiom).
- File-wide `// ignore_for_file: avoid_print` in `example/main.dart`.
- Remove invalid `@override` on `MutationSerializable` subclass `toJson` methods.
- Bonus: typed `Future<void>.delayed` + drop redundant import.

## Test plan
- [x] `dart analyze` (no flags, full repo) — 'No issues found!'.
- [x] `flutter test` — 143/143 pass.

Closes #111