### PR TITLE
feat(#113): hide *Key chain — query/infiniteQuery/definition/mutate on serializables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `QuerySerializableExtension.query({...})` — convenience method on the serializable, replaces the `request.queryKey.query(...)` chain. Same parameter surface as `QueryKey.query()`.
+- `InfiniteQuerySerializableExtension.infiniteQuery({...})` — convenience method on the serializable, replaces the `request.infiniteQueryKey.query(...)` chain. Same parameter surface as `InfiniteQueryKey.query()`.
+- `MutationSerializableExtension.definition({...})` — convenience method on the serializable, replaces the `request.mutationKey.definition(...)` chain when constructing a long-lived `Mutation` for `TypedMutationBuilder` / `TypedMutationListener`.
+- `MutationSerializableExtension.mutate({...})` — direct mutate verb on the serializable. Replaces the previous `request.mutationKey.mutate(...)` chain.
+
 ### Changed (breaking)
+- `MutationKey.mutate(...)` is removed. Migrate to `request.mutate(...)`:
+  ```dart
+  // before
+  await mutation.mutationKey.mutate(onSuccess: (...) => ...);
+  // after
+  await mutation.mutate(onSuccess: (...) => ...);
+  ```
+- `request.queryKey.query(...)` / `request.infiniteQueryKey.query(...)` / `request.mutationKey.definition(...)` chains in builder construction sites should migrate to the new convenience methods. The `*Key.query(...)` / `*Key.definition(...)` methods themselves remain available for advanced cases, but the `*Key` getters are intended for state-inspection (`exists`, `isPending`, `error`, `invalidate`, `updateData`) — not the rendering path.
+  ```dart
+  // before
+  TypedQueryBuilder(query: getUserQuery.queryKey.query(), builder: ...)
+  TypedInfiniteQueryBuilder(query: feed.infiniteQueryKey.query(), builder: ...)
+  TypedMutationBuilder(mutation: updateUser.mutationKey.definition(...), builder: ...)
+  // after
+  TypedQueryBuilder(query: getUserQuery.query(), builder: ...)
+  TypedInfiniteQueryBuilder(query: feed.infiniteQuery(), builder: ...)
+  TypedMutationBuilder(mutation: updateUser.definition(...), builder: ...)
+  ```
 - `MutationSerializable.mutationFn()` and `InfiniteQuerySerializable.queryFn(arg)` now return `Future<dynamic>` (matching `QuerySerializable.queryFn()`) and their result is passed through `responseHandler` before reaching the caller. Existing implementations whose return type was `Future<ReturnType>` continue to compile (Future<X> assigns to Future<dynamic>) and continue to work as long as their `responseHandler` accepts a `ReturnType` value (which all in-tree fixtures do).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -141,10 +141,9 @@ class UserProfileWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final getUserQuery = GetUserRequest(userId: 1, apiService: ApiService());
-    final queryKey = getUserQuery.queryKey;
 
     return FutureBuilder(
-      future: queryKey.query().fetch(),
+      future: getUserQuery.query().fetch(),
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           return Text('User: ${snapshot.data!.data!.name}');
@@ -166,13 +165,16 @@ void updateUser() async {
     apiService: ApiService(),
   );
 
-  final mutationKey = mutation.mutationKey;
-  final result = await mutationKey.mutate(
+  final result = await mutation.mutate(
     onSuccess: (user, request) => print('User updated: ${user.name}'),
     onError: (request, error, fallback) => print('Error: ${error.message}'),
   );
 }
 ```
+
+> Note: `mutation.mutationKey` and `query.queryKey` remain available for state inspection
+> (`exists`, `isPending`, `error`, `invalidate`, etc.). The convenience methods on the serializable
+> just hide the chain for the rendering-path verbs (`mutate`, `query`, `infiniteQuery`, `definition`).
 
 ## Key Concepts
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ void updateUser() async {
 }
 ```
 
-> Note: `mutation.mutationKey` and `query.queryKey` remain available for state inspection
+> Note: `mutation.mutationKey` and `getUserQuery.queryKey` remain available for state inspection
 > (`exists`, `isPending`, `error`, `invalidate`, etc.). The convenience methods on the serializable
 > just hide the chain for the rendering-path verbs (`mutate`, `query`, `infiniteQuery`, `definition`).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ Consumers therefore still need to learn the relevant parts of `cached_query_flut
 - **Cache key generation is unified.** All three serializables expose `String get keyGenerator`.
 - **Builders and listeners adapt the underlying streams.** `TypedQueryBuilder`, `TypedMutationBuilder`, `TypedInfiniteQueryBuilder`, `TypedQueryListener`, `TypedMutationListener` are thin wrappers over the upstream `Query.stream` / `Mutation.stream` / `InfiniteQuery.stream`.
 - **Error handling is uniform.** `QueryException` and `MutationException` are owned by this library; the `errorMapper` contract translates `ErrorType → QueryException/MutationException` consistently.
-- **Outputs are upstream types.** `queryKey.query()` returns `Query<T>`; `mutationKey.definition()` returns `Mutation<T, R>`; `infiniteQueryKey.query()` returns `InfiniteQuery<T, A>`. Consumers introspect `state` / `stream` / `fetch()` / `getNextPage()` directly on those.
+- **Outputs are upstream types.** `request.query()` returns `Query<T>`; `request.definition()` returns `Mutation<T, R>`; `request.infiniteQuery()` returns `InfiniteQuery<T, A>`. Consumers introspect `state` / `stream` / `fetch()` / `getNextPage()` directly on those. The `*Key` types (`queryKey`, `mutationKey`, `infiniteQueryKey`) remain on each serializable as the inspection surface (`exists`, `isPending`, `error`, `invalidate`, `updateData`, etc.) but are no longer required for the rendering path — the convenience methods on the serializable extension hide them.
 
 ## When to revisit
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -229,7 +229,7 @@ class UserProfileScreen extends StatelessWidget {
             // Typed Query Builder Example
             Expanded(
               child: TypedQueryBuilder<User>(
-                query: getUserQuery.queryKey.query(),
+                query: getUserQuery.query(),
                 builder: (context, state) {
                   if (state.isLoading) {
                     return Center(child: CircularProgressIndicator());
@@ -271,7 +271,7 @@ class UserProfileScreen extends StatelessWidget {
 
             // Typed Mutation Builder Example
             TypedMutationBuilder<User, UpdateUserRequest>(
-              mutation: updateUserMutation.mutationKey.definition(
+              mutation: updateUserMutation.definition(
                 onSuccess: (user, request) =>
                     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Successfully updated user: ${user.name}'))),
                 onError: (request, error, fallback) =>
@@ -301,7 +301,7 @@ class UserProfileScreen extends StatelessWidget {
 
             // Typed Query Listener Example (listens for changes without UI)
             TypedQueryListener<User>(
-              query: getUserQuery.queryKey.query(),
+              query: getUserQuery.query(),
               onChange: (context, state) => print('User query state changed'),
               onSuccess: (context, state) => print('User loaded: ${state.data?.name}'),
               onError: (context, state) => print('User query error: ${state.error}'),
@@ -335,12 +335,12 @@ class UsersListScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: Text('Users List'), backgroundColor: Colors.blue, foregroundColor: Colors.white),
       body: TypedMutationListener<User, UpdateUserRequest>(
-        mutation: refreshMutation.mutationKey.definition(),
+        mutation: refreshMutation.definition(),
         onSuccess: (context, state) => ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Refresh completed!'))),
         onError: (context, state) =>
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Refresh failed'), backgroundColor: Colors.red)),
         child: TypedInfiniteQueryBuilder<List<User>, int>(
-          query: getUsersPage.infiniteQueryKey.query(),
+          query: getUsersPage.infiniteQuery(),
           builder: (context, state, fetchNextPage, hasReachedMax) {
             if (state.isLoading && (state.data?.pages.isEmpty ?? true)) {
               return Center(child: CircularProgressIndicator());

--- a/lib/src/builders/infinite_query_builder.dart
+++ b/lib/src/builders/infinite_query_builder.dart
@@ -3,9 +3,12 @@ import 'package:cached_query_flutter/cached_query_flutter.dart';
 import 'package:typed_cached_query/src/builders/stream_backed_state.dart';
 
 /// A [TypedInfiniteQueryBuilder] widget that builds its child based on the state of an [InfiniteQuery].
-/// This builder only accepts infinite queries created from [InfiniteQueryKey.query()].
+///
+/// The [query] is normally produced by calling `request.infiniteQuery(...)` on an
+/// [InfiniteQuerySerializable] (e.g. `feed.infiniteQuery(prefetchPages: 2)`). The
+/// `*Key.query(...)` form is still accepted — it's the same call under the hood.
 class TypedInfiniteQueryBuilder<T, A> extends StatefulWidget {
-  /// The infinite query to listen to. Must be created using [InfiniteQueryKey.query()].
+  /// The infinite query to listen to. Typically built via `request.infiniteQuery(...)`.
   final InfiniteQuery<T, A> query;
 
   /// The builder function that creates the widget tree based on infinite query state.

--- a/lib/src/builders/mutation_builder.dart
+++ b/lib/src/builders/mutation_builder.dart
@@ -3,9 +3,13 @@ import 'package:cached_query_flutter/cached_query_flutter.dart';
 import 'package:typed_cached_query/src/builders/stream_backed_state.dart';
 
 /// A [TypedMutationBuilder] widget that builds its child based on the state of a [Mutation].
-/// This builder only accepts mutations created from [MutationKey.definition()].
+///
+/// The [mutation] is normally produced by calling `request.definition(...)` on a
+/// [MutationSerializable] (e.g. `updateUserMutation.definition(onSuccess: ...)`). The
+/// `*Key.definition(...)` form is still accepted — it's the same call under the hood.
+/// To trigger a one-shot mutation outside a builder, use `request.mutate(...)` instead.
 class TypedMutationBuilder<T, R> extends StatefulWidget {
-  /// The mutation to listen to. Must be created using [MutationKey.definition()].
+  /// The mutation to listen to. Typically built via `request.definition(...)`.
   final Mutation<T, R> mutation;
 
   /// The builder function that creates the widget tree based on mutation state.

--- a/lib/src/builders/mutation_listener.dart
+++ b/lib/src/builders/mutation_listener.dart
@@ -3,24 +3,47 @@ import 'package:cached_query_flutter/cached_query_flutter.dart';
 import 'package:typed_cached_query/src/builders/stream_backed_state.dart';
 
 /// A [TypedMutationListener] widget that listens to mutation state changes and calls callbacks.
-/// This listener only accepts mutations created from [MutationKey.definition()].
+///
+/// The [mutation] is normally produced by calling `request.definition(...)` on a
+/// [MutationSerializable] (e.g. `updateUserMutation.definition()`). The `*Key.definition(...)`
+/// form is still accepted — it's the same call under the hood.
+///
+/// ## Choosing between the listener callbacks and the data-pipeline callbacks
+///
+/// `request.definition(onSuccess: ..., onError: ...)` and the listener's [onSuccess] /
+/// [onError] / [onLoading] / [onData] callbacks fire at *different layers* — they are not
+/// duplicates:
+///
+/// - **`Mutation.onSuccess` / `Mutation.onError`** (passed via `request.definition(...)` or
+///   `request.mutate(...)`) — data-pipeline hooks owned by `cached_query`. Signatures take the
+///   raw payload and the originating request. No [BuildContext]. Use for analytics, cache
+///   invalidation, persistence — side effects that don't touch the widget tree.
+/// - **`TypedMutationListener.onSuccess` / `onError` / etc.** — widget-tree hooks owned by this
+///   listener. Signature `(BuildContext context, MutationState<T> state)`. Use for
+///   [Navigator.push], `ScaffoldMessenger.showSnackBar`, focus changes — anything that needs a
+///   context or only matters while this listener is mounted.
+///
+/// In short: data-pipeline → no context → use `request.definition(...)`; widget reaction →
+/// needs context → use the listener callback.
 class TypedMutationListener<T, R> extends StatefulWidget {
-  /// The mutation to listen to. Must be created using [MutationKey.definition()].
+  /// The mutation to listen to. Typically built via `request.definition(...)`.
   final Mutation<T, R> mutation;
 
   /// The child widget to render.
   final Widget child;
 
-  /// Called when the mutation state changes.
+  /// Widget-tree hook called when the mutation state changes. Receives [BuildContext] for
+  /// navigation / messenger / focus side effects. See class dartdoc for the contrast with
+  /// `Mutation.onSuccess` / `Mutation.onError` (data-pipeline hooks without context).
   final void Function(BuildContext context, MutationState<T> state)? onData;
 
-  /// Called when the mutation encounters an error.
+  /// Widget-tree hook called when the mutation transitions into an error state.
   final void Function(BuildContext context, MutationState<T> state)? onError;
 
-  /// Called when the mutation completes successfully.
+  /// Widget-tree hook called when the mutation transitions into a success state.
   final void Function(BuildContext context, MutationState<T> state)? onSuccess;
 
-  /// Called when the mutation starts loading.
+  /// Widget-tree hook called when the mutation transitions into a loading state.
   final void Function(BuildContext context, MutationState<T> state)? onLoading;
 
   /// Creates a [TypedMutationListener].

--- a/lib/src/builders/query_builder.dart
+++ b/lib/src/builders/query_builder.dart
@@ -3,9 +3,12 @@ import 'package:cached_query_flutter/cached_query_flutter.dart';
 import 'package:typed_cached_query/src/builders/stream_backed_state.dart';
 
 /// A [TypedQueryBuilder] widget that builds its child based on the state of a [Query].
-/// This builder only accepts queries created from [QueryKey.query()].
+///
+/// The [query] is normally produced by calling `request.query(...)` on a
+/// [QuerySerializable] (e.g. `getUserQuery.query(onSuccess: ..., config: ...)`). The
+/// `*Key.query(...)` form is still accepted — it's the same call under the hood.
 class TypedQueryBuilder<T> extends StatefulWidget {
-  /// The query to listen to. Must be created using [QueryKey.query()].
+  /// The query to listen to. Typically built via `request.query(...)`.
   final Query<T> query;
 
   /// The builder function that creates the widget tree based on query state.

--- a/lib/src/builders/query_listener.dart
+++ b/lib/src/builders/query_listener.dart
@@ -3,27 +3,52 @@ import 'package:cached_query_flutter/cached_query_flutter.dart';
 import 'package:typed_cached_query/src/builders/stream_backed_state.dart';
 
 /// A [TypedQueryListener] widget that listens to query state changes and calls callbacks.
-/// This listener only accepts queries created from [QueryKey.query()].
+///
+/// The [query] is normally produced by calling `request.query(...)` on a [QuerySerializable]
+/// (e.g. `getUserQuery.query()`). The `*Key.query(...)` form is still accepted — it's the same
+/// call under the hood.
+///
+/// ## Choosing between the listener callbacks and the data-pipeline callbacks
+///
+/// `request.query(onSuccess: ..., onError: ...)` and the listener's [onSuccess] / [onError] /
+/// [onLoading] / [onRefetching] / [onChange] callbacks fire at *different layers* — they are
+/// not duplicates:
+///
+/// - **`Query.onSuccess` / `Query.onError`** (passed via `request.query(...)`) — data-pipeline
+///   hooks owned by `cached_query`. Signature `(T data)` / `(dynamic error)`. No
+///   [BuildContext]. Use for analytics, persistence, side effects that don't touch the widget
+///   tree. Fires once per cached_query lifecycle event regardless of whether any widget is
+///   listening.
+/// - **`TypedQueryListener.onSuccess` / `onError` / etc.** — widget-tree hooks owned by this
+///   listener. Signature `(BuildContext context, QueryStatus<T> state)`. Use for
+///   [Navigator.push], `ScaffoldMessenger.showSnackBar`, focus changes — anything that needs a
+///   context or only matters while this listener is mounted.
+///
+/// In short: data-pipeline → no context → use `request.query(...)`; widget reaction → needs
+/// context → use the listener callback.
 class TypedQueryListener<T> extends StatefulWidget {
-  /// The query to listen to. Must be created using [QueryKey.query()].
+  /// The query to listen to. Typically built via `request.query(...)`.
   final Query<T> query;
 
   /// The child widget to render.
   final Widget child;
 
-  /// Called when the query state changes.
+  /// Widget-tree hook called when the query state changes. Receives [BuildContext] for
+  /// navigation / messenger / focus side effects. See class dartdoc for the contrast with
+  /// `Query.onSuccess` / `Query.onError` (data-pipeline hooks without context).
   final void Function(BuildContext context, QueryStatus<T> state)? onChange;
 
-  /// Called when the query encounters an error.
+  /// Widget-tree hook called when the query transitions into an error state.
   final void Function(BuildContext context, QueryStatus<T> state)? onError;
 
-  /// Called when the query loads successfully.
+  /// Widget-tree hook called when the query transitions into a success state.
   final void Function(BuildContext context, QueryStatus<T> state)? onSuccess;
 
-  /// Called when the query starts loading from a non-loading, no-data state (cold start).
+  /// Widget-tree hook called when the query starts loading from a no-data state (cold start).
   final void Function(BuildContext context, QueryStatus<T> state)? onLoading;
 
-  /// Called when the query starts a refetch — i.e. transitions into loading while data is already present.
+  /// Widget-tree hook called when the query starts a refetch — i.e. transitions into loading
+  /// while data is already present.
   final void Function(BuildContext context, QueryStatus<T> state)? onRefetching;
 
   /// Creates a [TypedQueryListener].

--- a/lib/src/models/mutation_key.dart
+++ b/lib/src/models/mutation_key.dart
@@ -96,32 +96,6 @@ class MutationKey<RequestType extends MutationSerializable<RequestType, ReturnTy
   bool get exists => _getMutation != null;
   bool get isMutating => _cache.contains(_valueKey);
 
-  Future<MutationState<ReturnType?>> mutate({
-    void Function(RequestType, MutationException, ReturnType?)? onError,
-    void Function(ReturnType, RequestType)? onSuccess,
-    MutationCache? cache,
-    FutureOr<ReturnType> Function(RequestType)? onStartMutation,
-    List<QueryKey<dynamic, dynamic, dynamic>>? invalidateQueries,
-    List<QueryKey<dynamic, dynamic, dynamic>>? refetchQueries,
-    int? retryAttempts,
-    bool Function(ErrorType)? shouldRetry,
-    int? timeoutSeconds,
-    void Function(RequestType)? onTimeout,
-    Duration Function(int attempt)? backoff,
-  }) => definition(
-    onError: onError,
-    onSuccess: onSuccess,
-    cache: cache,
-    onStartMutation: onStartMutation,
-    invalidateQueries: invalidateQueries,
-    refetchQueries: refetchQueries,
-    retryAttempts: retryAttempts,
-    shouldRetry: shouldRetry,
-    timeoutSeconds: timeoutSeconds,
-    onTimeout: onTimeout,
-    backoff: backoff,
-  ).mutate(request);
-
   bool get isPending => _getMutation != null && _getMutation!.state.isLoading && _getMutation!.state.data == null;
 
   bool get isRefetching => _getMutation != null && _getMutation!.state.isLoading && _getMutation!.state.data != null;

--- a/lib/src/models/serializable.dart
+++ b/lib/src/models/serializable.dart
@@ -39,7 +39,7 @@ import 'package:typed_cached_query/src/models/infinite_query_key.dart';
 /// ## Usage
 /// ```dart
 /// final query = GetUserQuery(123);
-/// final result = await query.queryKey.query().result;
+/// final result = await query.query().result;
 /// ```
 ///
 /// ## Advanced Features
@@ -172,7 +172,7 @@ abstract class QuerySerializable<ReturnType, ErrorType> {
 /// ## Usage
 /// ```dart
 /// final mutation = CreateUserMutation(name: 'John', email: 'john@example.com');
-/// final result = await mutation.mutationKey.mutate();
+/// final result = await mutation.mutate();
 /// ```
 ///
 /// ## Type Parameters
@@ -367,13 +367,77 @@ abstract class InfiniteQuerySerializable<ReturnType, RequestData, ErrorType> {
 }
 
 extension QuerySerializableExtension<T extends QuerySerializable<ReturnType, ErrorType>, ReturnType, ErrorType> on T {
+  /// Returns a [QueryKey] for state inspection (`exists`, `isPending`, `error`, `invalidate`,
+  /// `updateData`, `fetch`, etc.). Most rendering paths should use [query] instead.
   QueryKey<T, ReturnType, ErrorType> get queryKey => QueryKey(this);
+
+  /// Convenience entry point: build a configured `Query` directly from the serializable.
+  ///
+  /// **Purpose:** Replaces the previous `request.queryKey.query(...)` chain — `*Key` is a
+  /// wrapper-internal abstraction, not part of the rendering path. Per-builder configuration
+  /// (`onSuccess`, `onError`, `config`, `cache`) is preserved so different builders can resolve
+  /// the same serializable with different behaviour.
+  /// **Example:**
+  /// ```dart
+  /// TypedQueryBuilder<User>(
+  ///   query: getUserQuery.query(onSuccess: (u) => analytics.userLoaded(u)),
+  ///   builder: (context, state) => ...,
+  /// )
+  /// ```
+  /// **Returns:** A configured [Query] backed by the same `*Key` implementation.
+  Query<ReturnType> query({
+    void Function(QueryException)? onError,
+    void Function(ReturnType)? onSuccess,
+    QueryConfig<ReturnType>? config,
+    CachedQuery? cache,
+  }) => queryKey.query(onError: onError, onSuccess: onSuccess, config: config, cache: cache);
 }
 
 extension MutationSerializableExtension<T extends MutationSerializable<T, ReturnType, ErrorType>, ReturnType, ErrorType> on T {
-  /// Returns a [MutationKey] for state inspection (`exists`, `isPending`, `error`, etc.) and for
-  /// constructing a long-lived `Mutation` instance via `mutationKey.definition(...)`.
+  /// Returns a [MutationKey] for state inspection (`exists`, `isPending`, `error`, etc.).
+  /// Most rendering paths should use [definition] to build a `Mutation` for builders, or [mutate]
+  /// to trigger a single mutation directly.
   MutationKey<T, ReturnType, ErrorType> get mutationKey => MutationKey(this);
+
+  /// Convenience entry point: build a configured `Mutation` directly from the serializable for
+  /// use with `TypedMutationBuilder` / `TypedMutationListener`.
+  ///
+  /// **Purpose:** Replaces the previous `request.mutationKey.definition(...)` chain — `*Key` is a
+  /// wrapper-internal abstraction, not part of the rendering path. Per-builder configuration
+  /// (`onSuccess`, `onError`, `cache`, retry/timeout, optimistic updates) is preserved.
+  /// **Example:**
+  /// ```dart
+  /// TypedMutationBuilder<User, UpdateUserRequest>(
+  ///   mutation: updateUserMutation.definition(onSuccess: (user, _) => toast(user)),
+  ///   builder: (context, state, mutate) => ...,
+  /// )
+  /// ```
+  /// **Returns:** A configured [Mutation] backed by the same `*Key` implementation.
+  Mutation<ReturnType, T> definition({
+    void Function(T, MutationException, ReturnType?)? onError,
+    void Function(ReturnType, T)? onSuccess,
+    MutationCache? cache,
+    FutureOr<ReturnType> Function(T)? onStartMutation,
+    List<QueryKey<dynamic, dynamic, dynamic>>? invalidateQueries,
+    List<QueryKey<dynamic, dynamic, dynamic>>? refetchQueries,
+    int? retryAttempts,
+    bool Function(ErrorType)? shouldRetry,
+    int? timeoutSeconds,
+    void Function(T)? onTimeout,
+    Duration Function(int attempt)? backoff,
+  }) => mutationKey.definition(
+        onError: onError,
+        onSuccess: onSuccess,
+        cache: cache,
+        onStartMutation: onStartMutation,
+        invalidateQueries: invalidateQueries,
+        refetchQueries: refetchQueries,
+        retryAttempts: retryAttempts,
+        shouldRetry: shouldRetry,
+        timeoutSeconds: timeoutSeconds,
+        onTimeout: onTimeout,
+        backoff: backoff,
+      );
 
   /// Convenience entry point: trigger this mutation directly from the serializable.
   ///
@@ -423,7 +487,39 @@ extension InfiniteQuerySerializableExtension<
   ErrorType
 >
     on T {
+  /// Returns an [InfiniteQueryKey] for state inspection (`exists`, `isPending`, `hasReachedMax`,
+  /// `allPages`, `pageArgs`, `fetch`, `fetchNextPage`, `refetch`, `invalidate`, `updateData`,
+  /// `error`). Most rendering paths should use [infiniteQuery] instead.
   InfiniteQueryKey<T, ReturnType, RequestData, ErrorType> get infiniteQueryKey => InfiniteQueryKey(this);
+
+  /// Convenience entry point: build a configured `InfiniteQuery` directly from the serializable.
+  ///
+  /// **Purpose:** Replaces the previous `request.infiniteQueryKey.query(...)` chain — `*Key` is a
+  /// wrapper-internal abstraction, not part of the rendering path. Per-builder configuration
+  /// (`onSuccess`, `onError`, `config`, `cache`, `prefetchPages`, `initialData`) is preserved.
+  /// **Example:**
+  /// ```dart
+  /// TypedInfiniteQueryBuilder<Page, Args>(
+  ///   query: feed.infiniteQuery(prefetchPages: 2),
+  ///   builder: (context, state) => ...,
+  /// )
+  /// ```
+  /// **Returns:** A configured [InfiniteQuery] backed by the same `*Key` implementation.
+  InfiniteQuery<ReturnType, RequestData> infiniteQuery({
+    void Function(QueryException)? onError,
+    void Function(InfiniteQueryData<ReturnType, RequestData>)? onSuccess,
+    QueryConfig<InfiniteQueryData<ReturnType, RequestData>>? config,
+    CachedQuery? cache,
+    int? prefetchPages,
+    InfiniteQueryData<ReturnType, RequestData>? initialData,
+  }) => infiniteQueryKey.query(
+        onError: onError,
+        onSuccess: onSuccess,
+        config: config,
+        cache: cache,
+        prefetchPages: prefetchPages,
+        initialData: initialData,
+      );
 }
 
 class OnErrorResults<RequestType, ReturnType> {

--- a/lib/src/models/serializable.dart
+++ b/lib/src/models/serializable.dart
@@ -371,7 +371,49 @@ extension QuerySerializableExtension<T extends QuerySerializable<ReturnType, Err
 }
 
 extension MutationSerializableExtension<T extends MutationSerializable<T, ReturnType, ErrorType>, ReturnType, ErrorType> on T {
+  /// Returns a [MutationKey] for state inspection (`exists`, `isPending`, `error`, etc.) and for
+  /// constructing a long-lived `Mutation` instance via `mutationKey.definition(...)`.
   MutationKey<T, ReturnType, ErrorType> get mutationKey => MutationKey(this);
+
+  /// Convenience entry point: trigger this mutation directly from the serializable.
+  ///
+  /// **Purpose:** Replaces the previous `mutation.mutationKey.mutate(...)` chain with a single
+  /// verb on the serializable. The full named-parameter surface of [MutationKey] is preserved.
+  /// **Example:**
+  /// ```dart
+  /// final result = await createUserMutation.mutate(
+  ///   onSuccess: (user, _) => print(user),
+  /// );
+  /// ```
+  /// **Returns:** A [Future] resolving to the final [MutationState], identical to the
+  /// `mutationKey.definition(...).mutate(request)` path used internally.
+  Future<MutationState<ReturnType?>> mutate({
+    void Function(T, MutationException, ReturnType?)? onError,
+    void Function(ReturnType, T)? onSuccess,
+    MutationCache? cache,
+    FutureOr<ReturnType> Function(T)? onStartMutation,
+    List<QueryKey<dynamic, dynamic, dynamic>>? invalidateQueries,
+    List<QueryKey<dynamic, dynamic, dynamic>>? refetchQueries,
+    int? retryAttempts,
+    bool Function(ErrorType)? shouldRetry,
+    int? timeoutSeconds,
+    void Function(T)? onTimeout,
+    Duration Function(int attempt)? backoff,
+  }) => mutationKey
+      .definition(
+        onError: onError,
+        onSuccess: onSuccess,
+        cache: cache,
+        onStartMutation: onStartMutation,
+        invalidateQueries: invalidateQueries,
+        refetchQueries: refetchQueries,
+        retryAttempts: retryAttempts,
+        shouldRetry: shouldRetry,
+        timeoutSeconds: timeoutSeconds,
+        onTimeout: onTimeout,
+        backoff: backoff,
+      )
+      .mutate(this);
 }
 
 extension InfiniteQuerySerializableExtension<

--- a/lib/src/models/serializable.dart
+++ b/lib/src/models/serializable.dart
@@ -39,7 +39,7 @@ import 'package:typed_cached_query/src/models/infinite_query_key.dart';
 /// ## Usage
 /// ```dart
 /// final query = GetUserQuery(123);
-/// final result = await query.query().result;
+/// final result = await query.query().fetch();
 /// ```
 ///
 /// ## Advanced Features
@@ -186,7 +186,8 @@ abstract class MutationSerializable<RequestType extends MutationSerializable<Req
   /// can track in-flight state, deduplicate concurrent submissions, and dispatch optimistic updates.
   /// **Returns:** A stable, unique string per mutation type. Override per request only when the
   /// mutation is parameterised by data that should partition cache state (e.g. user id).
-  /// **Example:** `String get keyGenerator => 'create_user';`
+  /// **Example:** `String get keyGenerator => 'create_user_$email';` — include any per-instance
+  /// data that should partition cache state.
   String get keyGenerator;
 
   /// Maps a domain-specific [ErrorType] into a typed [OnErrorResults] for the mutation pipeline.
@@ -272,8 +273,8 @@ abstract class MutationSerializable<RequestType extends MutationSerializable<Req
 /// ## Usage
 /// ```dart
 /// final query = GetUsersInfiniteQuery();
-/// final infiniteQuery = query.infiniteQueryKey.infiniteQuery();
-/// await infiniteQuery.fetchNext(); // Load more pages
+/// final infiniteQuery = query.infiniteQuery();
+/// await infiniteQuery.getNextPage(); // Load more pages
 /// ```
 ///
 /// ## Type Parameters
@@ -385,6 +386,7 @@ extension QuerySerializableExtension<T extends QuerySerializable<ReturnType, Err
   /// )
   /// ```
   /// **Returns:** A configured [Query] backed by the same `*Key` implementation.
+  /// **See also:** [QueryKey.query] for the underlying parameter contract.
   Query<ReturnType> query({
     void Function(QueryException)? onError,
     void Function(ReturnType)? onSuccess,
@@ -413,6 +415,7 @@ extension MutationSerializableExtension<T extends MutationSerializable<T, Return
   /// )
   /// ```
   /// **Returns:** A configured [Mutation] backed by the same `*Key` implementation.
+  /// **See also:** [MutationKey.definition] for the underlying parameter contract.
   Mutation<ReturnType, T> definition({
     void Function(T, MutationException, ReturnType?)? onError,
     void Function(ReturnType, T)? onSuccess,
@@ -451,6 +454,7 @@ extension MutationSerializableExtension<T extends MutationSerializable<T, Return
   /// ```
   /// **Returns:** A [Future] resolving to the final [MutationState], identical to the
   /// `mutationKey.definition(...).mutate(request)` path used internally.
+  /// **See also:** [MutationKey.definition] for the underlying parameter contract.
   Future<MutationState<ReturnType?>> mutate({
     void Function(T, MutationException, ReturnType?)? onError,
     void Function(ReturnType, T)? onSuccess,
@@ -505,6 +509,7 @@ extension InfiniteQuerySerializableExtension<
   /// )
   /// ```
   /// **Returns:** A configured [InfiniteQuery] backed by the same `*Key` implementation.
+  /// **See also:** [InfiniteQueryKey.query] for the underlying parameter contract.
   InfiniteQuery<ReturnType, RequestData> infiniteQuery({
     void Function(QueryException)? onError,
     void Function(InfiniteQueryData<ReturnType, RequestData>)? onSuccess,

--- a/test/src/integration_test.dart
+++ b/test/src/integration_test.dart
@@ -131,7 +131,7 @@ void main() {
 
       // Execute mutation
       User? successResult;
-      final result = await mutationKey.mutate(onSuccess: (data, req) => successResult = data);
+      final result = await request.mutate(onSuccess: (User data, CreateUserRequest req) => successResult = data);
 
       // Verify result
       expect(result.data, createdUser);
@@ -149,13 +149,11 @@ void main() {
         }),
       );
 
-      final mutationKey = request.mutationKey;
-
       MutationException? capturedError;
       CreateUserRequest? errorRequest;
 
-      await mutationKey.mutate(
-        onError: (req, error, fallback) {
+      await request.mutate(
+        onError: (CreateUserRequest req, MutationException error, User? fallback) {
           capturedError = error;
           errorRequest = req;
         },
@@ -182,9 +180,7 @@ void main() {
         return User(id: 123, name: request.name, email: request.email);
       });
 
-      final mutationKey = retryableRequest.mutationKey;
-
-      final result = await mutationKey.mutate(
+      final result = await retryableRequest.mutate(
         retryAttempts: 2,
         shouldRetry: (_) => true, // Retry all errors
       );
@@ -202,11 +198,9 @@ void main() {
         return User(id: 5, name: 'Slow', email: 'slow@example.com');
       });
 
-      final mutationKey = request.mutationKey;
-
       CreateUserRequest? timeoutRequest;
 
-      final result = await mutationKey.mutate(timeoutSeconds: 1, onTimeout: (req) => timeoutRequest = req);
+      final result = await request.mutate(timeoutSeconds: 1, onTimeout: (CreateUserRequest req) => timeoutRequest = req);
 
       // onTimeout should have been called, result should be null since onTimeout returns void
       expect(timeoutRequest, request);
@@ -237,7 +231,7 @@ void main() {
       request.queryKey.updateData((_) => optimisticUser);
 
       // Execute mutation
-      final result = await updateRequest.mutationKey.mutate();
+      final result = await updateRequest.mutate();
 
       // Manually invalidate and refetch the query after mutation
       request.queryKey.invalidate(refetchActive: true);
@@ -271,7 +265,7 @@ void main() {
 
       // Test mutation error
       MutationException? mutationError;
-      await request.mutationKey.mutate(onError: (req, error, fallback) => mutationError = error);
+      await request.mutate(onError: (req, error, fallback) => mutationError = error);
 
       expect(mutationError, isNotNull);
       expect(mutationError!.statusCode, 400);

--- a/test/src/integration_test.dart
+++ b/test/src/integration_test.dart
@@ -96,7 +96,7 @@ void main() {
       final getUsersRequest = GetAllUsersQueryRequest(apiService: mockApiService, cache: cachedQuery);
 
       // User query should succeed
-      final userResult = await userQuery.queryKey.query().fetch();
+      final userResult = await userQuery.query().fetch();
       expect(userResult.data?.id, users[0].id);
       expect(userResult.data?.name, users[0].name);
       expect(userResult.data?.email, users[0].email);
@@ -104,7 +104,7 @@ void main() {
       // Users query should fail with network error
       QueryException? usersError;
       try {
-        await getUsersRequest.queryKey.query(onError: (error) => usersError = error).fetch();
+        await getUsersRequest.query(onError: (QueryException error) => usersError = error).fetch();
       } catch (e) {
         // Expected
       }
@@ -222,7 +222,7 @@ void main() {
       when(mockApiService.updateUser(updateRequest)).thenAnswer((_) async => updatedUser);
 
       // Fetch initial data
-      final initialResult = await request.queryKey.query().fetch();
+      final initialResult = await request.query().fetch();
       expect(request.queryKey.exists, true);
       expect(initialResult.data, initialUser);
 
@@ -255,7 +255,7 @@ void main() {
       // Test query error
       QueryException? queryError;
       try {
-        await query.queryKey.query(onError: (error) => queryError = error).fetch();
+        await query.query(onError: (QueryException error) => queryError = error).fetch();
       } catch (e) {
         // Expected
       }

--- a/test/src/models/infinite_query_key_test.dart
+++ b/test/src/models/infinite_query_key_test.dart
@@ -606,6 +606,39 @@ void main() {
     });
   });
 
+  group('InfiniteQuerySerializable.infiniteQuery convenience method', () {
+    test('serializable.infiniteQuery() resolves to the same InfiniteQuery as infiniteQueryKey.query()', () async {
+      final pageResponse = PagedResponse(
+        users: [User(id: 1, name: 'Convenience', email: 'c@example.com')],
+        page: 1,
+        totalPages: 1,
+        hasNext: false,
+      );
+      when(mockApiService.getUsersPage(PageArgs(page: 1, limit: 10))).thenAnswer((_) async => pageResponse);
+
+      final request = GetUsersInfiniteQuery(apiService: mockApiService, localCache: cachedQuery);
+      // No `.infiniteQueryKey` chain — this is the new public entry point.
+      final result = await request.infiniteQuery().fetch();
+
+      expect(result.data?.pages.first.users.first.name, 'Convenience');
+    });
+
+    test('serializable.infiniteQuery(...) forwards onError', () async {
+      when(mockApiService.getUsersPage(any)).thenThrow(ApiError('Internal', 500));
+
+      final request = GetUsersInfiniteQuery(apiService: mockApiService, localCache: cachedQuery);
+      QueryException? captured;
+      final query = request.infiniteQuery(onError: (error) => captured = error);
+
+      try {
+        await query.fetch();
+      } catch (_) {/* expected */}
+
+      expect(captured, isNotNull);
+      expect(captured!.statusCode, 500);
+    });
+  });
+
   group('InfiniteQueryKey responseHandler wiring', () {
     test('queryFn raw page is passed through responseHandler before reaching state', () async {
       // Fixture's queryFn returns a Map; responseHandler builds a PagedResponse with a sentinel

--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -134,9 +134,8 @@ void main() {
     test('should generate correct key from request', () {
       final request = CreateUserRequest(name: 'John', email: 'john@example.com');
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final mutationKey = MutationKey(mutation);
 
-      expect(mutationKey, isNotNull);
+      expect(mutation.mutationKey, isNotNull);
     });
 
     test('should return mutation key from serializable', () {
@@ -150,7 +149,7 @@ void main() {
     test('should indicate mutation does not exist initially', () {
       final request = CreateUserRequest(name: 'John', email: 'john@example.com');
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final mutationKey = MutationKey(mutation);
+      final mutationKey = mutation.mutationKey;
 
       expect(mutationKey.exists, false);
       expect(mutationKey.isPending, false);
@@ -167,10 +166,9 @@ void main() {
 
       when(mockApiService.createUser(request)).thenAnswer((_) async => user);
 
-      final mutation = CreateUserMutation(request: request, apiService: mockApiService);
-      final mutationKey = MutationKey(mutation);
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
 
-      final result = await mutationKey.mutate();
+      final result = await mutation.mutate();
 
       expect(result.data, user);
       verify(mockApiService.createUser(request)).called(1);
@@ -182,10 +180,9 @@ void main() {
       when(mockApiService.createUser(request)).thenThrow(ValidationError('email', 'Invalid email format'));
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final mutationKey = MutationKey(mutation);
 
       MutationException? capturedError;
-      await mutationKey.mutate(onError: (req, error, fallback) => capturedError = error);
+      await mutation.mutate(onError: (req, error, fallback) => capturedError = error);
 
       expect(capturedError, isNotNull);
       expect(capturedError!.message, contains('Validation failed on email'));
@@ -198,10 +195,9 @@ void main() {
       when(mockApiService.createUser(request)).thenThrow(Exception('Database connection failed'));
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final mutationKey = MutationKey(mutation);
 
       expect(
-        () => mutationKey.mutate(),
+        () => mutation.mutate(),
         throwsA(isA<MutationException>().having((e) => e.message, 'message', contains('An unhandled exception has taken place'))),
       );
     });
@@ -218,11 +214,10 @@ void main() {
       });
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final mutationKey = MutationKey(mutation);
 
       // When no onTimeout is provided, TimeoutException becomes MutationException (fail fast)
       expect(
-        () => mutationKey.mutate(timeoutSeconds: 1), // 1 second timeout, but response takes 2 seconds
+        () => mutation.mutate(timeoutSeconds: 1), // 1 second timeout, but response takes 2 seconds
         throwsA(isA<MutationException>().having((e) => e.message, 'message', contains('An unhandled exception has taken place'))),
       );
     });
@@ -238,10 +233,9 @@ void main() {
       });
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final mutationKey = MutationKey(mutation);
 
       // When onTimeout is provided, TimeoutException is rethrown → Mutation catches it → calls onTimeout
-      final result = await mutationKey.mutate(
+      final result = await mutation.mutate(
         timeoutSeconds: 1, // 1 second timeout, but response takes 2 seconds
         onTimeout: (req) => timeoutRequest = req,
       );
@@ -255,10 +249,9 @@ void main() {
     test('should throw ArgumentError if onTimeout provided without timeoutSeconds', () {
       final request = CreateUserRequest(name: 'Test', email: 'test@example.com');
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final mutationKey = MutationKey(mutation);
 
       expect(
-        () => mutationKey.mutate(onTimeout: (req) => {}), // onTimeout without timeoutSeconds
+        () => mutation.mutate(onTimeout: (req) => {}), // onTimeout without timeoutSeconds
         throwsA(isA<ArgumentError>().having((e) => e.message, 'message', contains('If onTimeout is provided, timeoutSeconds must also be provided'))),
       );
     });
@@ -270,9 +263,8 @@ void main() {
       when(mockApiService.createUser(request)).thenAnswer((_) async => user);
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final mutationKey = MutationKey(mutation);
 
-      final result = await mutationKey.mutate(); // No timeout parameters
+      final result = await mutation.mutate(); // No timeout parameters
 
       expect(result.data, user);
       verify(mockApiService.createUser(request)).called(1);
@@ -286,8 +278,8 @@ void main() {
       when(mockApiService.createUser(request)).thenAnswer((_) async => user);
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final mutationKey = MutationKey(mutation);
-      await mutationKey.mutate();
+      final mutationKey = mutation.mutationKey;
+      await mutation.mutate();
 
       expect(mutationKey.isError, isFalse);
       expect(mutationKey.error, isNull, reason: 'error must mirror isError — never returns a value when isError is false');
@@ -298,9 +290,9 @@ void main() {
       when(mockApiService.createUser(request)).thenThrow(ValidationError('email', 'taken'));
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final mutationKey = MutationKey(mutation);
+      final mutationKey = mutation.mutationKey;
       // mutate does NOT throw for ErrorType — it maps via errorMapper and surfaces via state.
-      await mutationKey.mutate();
+      await mutation.mutate();
 
       expect(mutationKey.isError, isTrue);
       final err = mutationKey.error;
@@ -324,13 +316,13 @@ void main() {
       when(mockApiService.createUser(request)).thenThrow(ValidationError('email', 'taken'));
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final mutationKey = MutationKey(mutation);
-      await mutationKey.mutate();
+      final mutationKey = mutation.mutationKey;
+      await mutation.mutate();
       expect(mutationKey.isError, isTrue);
 
       reset(mockApiService);
       when(mockApiService.createUser(request)).thenAnswer((_) async => User(id: 9, name: 'Flip', email: 'flip@example.com'));
-      await mutationKey.mutate();
+      await mutation.mutate();
 
       expect(mutationKey.isError, isFalse, reason: 'after a successful mutate the wrapper must report not-error');
       expect(mutationKey.error, isNull, reason: 'after a successful mutate .error must mirror isError and be null');
@@ -349,7 +341,7 @@ void main() {
       });
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final result = await MutationKey(mutation).mutate(retryAttempts: 2, shouldRetry: (_) => true);
+      final result = await mutation.mutate(retryAttempts: 2, shouldRetry: (_) => true);
 
       expect(result.data, user);
       verify(mockApiService.createUser(request)).called(3);
@@ -372,7 +364,7 @@ void main() {
       }
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      await MutationKey(mutation).mutate(retryAttempts: 2, shouldRetry: (_) => true, backoff: record);
+      await mutation.mutate(retryAttempts: 2, shouldRetry: (_) => true, backoff: record);
 
       expect(invocations, [1, 2], reason: 'backoff is called once between attempts, with a 1-based attempt index');
     });
@@ -389,7 +381,7 @@ void main() {
       }
 
       final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
-      final result = await MutationKey(mutation).mutate(backoff: record);
+      final result = await mutation.mutate(backoff: record);
 
       expect(result.data, user);
       expect(invoked, isFalse);
@@ -398,6 +390,33 @@ void main() {
     test('defaultMutationBackoff returns 100 ms × attempt', () {
       expect(defaultMutationBackoff(1), const Duration(milliseconds: 100));
       expect(defaultMutationBackoff(3), const Duration(milliseconds: 300));
+    });
+  });
+
+  group('MutationSerializable.mutate convenience getter', () {
+    test('serializable.mutate(...) executes the same pipeline as the previous mutationKey.mutate', () async {
+      final request = CreateUserRequest(name: 'Bo', email: 'bo@example.com');
+      final user = User(id: 7, name: 'Bo', email: 'bo@example.com');
+      when(mockApiService.createUser(request)).thenAnswer((_) async => user);
+
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      // No `.mutationKey` chain — this is the new public entry point.
+      final result = await mutation.mutate();
+
+      expect(result.data, user);
+      verify(mockApiService.createUser(request)).called(1);
+    });
+
+    test('serializable.mutate(...) forwards optional parameters (onError)', () async {
+      final request = CreateUserRequest(name: 'Forwarded', email: 'f@b.c');
+      when(mockApiService.createUser(request)).thenThrow(ValidationError('email', 'taken'));
+
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      MutationException? captured;
+      await mutation.mutate(onError: (req, err, fb) => captured = err);
+
+      expect(captured, isA<MutationException>());
+      expect(captured!.statusCode, 400);
     });
   });
 
@@ -415,7 +434,7 @@ void main() {
 
       Object? thrown;
       try {
-        await MutationKey<_ParseFailingMutation, User, ValidationError>(mutation).mutate(
+        await mutation.mutate(
           retryAttempts: 3,
           shouldRetry: (_) => true,
         );
@@ -437,7 +456,7 @@ void main() {
       // a User with a sentinel suffix. If responseHandler were bypassed, result.data would be the
       // raw Map (not a User) and the assertions would fail.
       final mutation = _MapMutation(returnRaw: {'id': 7, 'name': 'Raw', 'email': 'raw@example.com'}, cache: mutationCache);
-      final result = await MutationKey(mutation).mutate();
+      final result = await mutation.mutate();
 
       expect(result.data, isA<User>(), reason: 'mutate result must be the User produced by responseHandler, not the raw Map from mutationFn');
       expect(result.data!.name, endsWith('-via-responseHandler'), reason: 'sentinel suffix proves responseHandler ran');

--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -393,6 +393,34 @@ void main() {
     });
   });
 
+  group('MutationSerializable.definition convenience method', () {
+    test('serializable.definition() resolves to a Mutation that can be triggered like mutationKey.definition()', () async {
+      final request = CreateUserRequest(name: 'Defn', email: 'd@example.com');
+      final user = User(id: 8, name: 'Defn', email: 'd@example.com');
+      when(mockApiService.createUser(request)).thenAnswer((_) async => user);
+
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      // No `.mutationKey` chain — this is the new public entry point for builders.
+      final defn = mutation.definition();
+      final result = await defn.mutate(mutation);
+
+      expect(result.data, user);
+    });
+
+    test('serializable.definition(...) forwards onSuccess', () async {
+      final request = CreateUserRequest(name: 'Forward', email: 'f@b.c');
+      final user = User(id: 9, name: 'Forward', email: 'f@b.c');
+      when(mockApiService.createUser(request)).thenAnswer((_) async => user);
+
+      final mutation = CreateUserMutation(request: request, apiService: mockApiService, cache: mutationCache);
+      User? observed;
+      final defn = mutation.definition(onSuccess: (User u, CreateUserMutation _) => observed = u);
+      await defn.mutate(mutation);
+
+      expect(observed, user);
+    });
+  });
+
   group('MutationSerializable.mutate convenience getter', () {
     test('serializable.mutate(...) executes the same pipeline as the previous mutationKey.mutate', () async {
       final request = CreateUserRequest(name: 'Bo', email: 'bo@example.com');

--- a/test/src/models/mutation_key_test.dart
+++ b/test/src/models/mutation_key_test.dart
@@ -421,7 +421,7 @@ void main() {
     });
   });
 
-  group('MutationSerializable.mutate convenience getter', () {
+  group('MutationSerializable.mutate convenience method', () {
     test('serializable.mutate(...) executes the same pipeline as the previous mutationKey.mutate', () async {
       final request = CreateUserRequest(name: 'Bo', email: 'bo@example.com');
       final user = User(id: 7, name: 'Bo', email: 'bo@example.com');

--- a/test/src/models/query_key_test.dart
+++ b/test/src/models/query_key_test.dart
@@ -219,7 +219,7 @@ void main() {
       });
 
       final request = GetUserQuery(userId: 321, apiService: mockApiService, localCache: cachedQuery);
-      final query = request.queryKey.query();
+      final query = request.query();
 
       Object? captured;
       try {
@@ -238,7 +238,7 @@ void main() {
       when(mockApiService.getUser(1)).thenAnswer((_) async => user);
 
       final request = _BadResponseQuery(apiService: mockApiService, localCache: cachedQuery);
-      final query = request.queryKey.query();
+      final query = request.query();
 
       Object? captured;
       try {
@@ -491,6 +491,42 @@ void main() {
       final result = await fetchFunction();
 
       expect(result, null);
+    });
+  });
+
+  group('QuerySerializable.query convenience method', () {
+    test('serializable.query() resolves to the same Query as queryKey.query()', () async {
+      final user = User(id: 1, name: 'Convenience', email: 'c@example.com');
+      when(mockApiService.getUser(1)).thenAnswer((_) async => user);
+
+      final request = GetUserQuery(userId: 1, apiService: mockApiService, localCache: cachedQuery);
+      // No `.queryKey` chain — this is the new public entry point.
+      final result = await request.query().fetch();
+
+      expect(result.data, user);
+      verify(mockApiService.getUser(1)).called(1);
+    });
+
+    test('serializable.query(...) forwards onError', () async {
+      when(mockApiService.getUser(404)).thenThrow(ApiError('User not found', 404));
+
+      final request = GetUserQuery(userId: 404, apiService: mockApiService, localCache: cachedQuery);
+      QueryException? captured;
+      final query = request.query(onError: (error) => captured = error);
+
+      try {
+        await query.fetch();
+      } catch (_) {/* expected */}
+
+      expect(captured, isNotNull);
+      expect(captured!.statusCode, 404);
+    });
+
+    test('serializable.query(config:) forwards QueryConfig (storeQuery validation surfaces)', () {
+      final request = _GetUserQueryNoSerializer(userId: 7, apiService: mockApiService, localCache: cachedQuery);
+      // _GetUserQueryNoSerializer sets storeQuery=true with no serializer; passing a config must surface the same
+      // ArgumentError as queryKey.query(config:) — proves the config arg is forwarded, not dropped.
+      expect(() => request.query(config: QueryConfig()), throwsA(isA<ArgumentError>()));
     });
   });
 }


### PR DESCRIPTION
Closes #113

## Summary

Hides one layer of wrapper internals (`*Key`) from the rendering-path verbs by exposing them on the serializable extensions. Users now call `request.mutate(...)`, `request.query(...)`, `request.infiniteQuery(...)`, `request.definition(...)` instead of chaining through `.mutationKey` / `.queryKey` / `.infiniteQueryKey`.

The `*Key` types remain on each serializable for state inspection (`exists`, `isPending`, `error`, `invalidate`, `updateData`, etc.) — they're just no longer required for the common rendering path.

## What changed (vs. the original issue)

The original spec proposed making the **builder/listener widgets** accept serializables (with new `E` generics, forwarded `onSuccess`/`onError`/`config`/etc. params, and `.fromQuery` escape hatches). After implementing Step 1, we revised the plan: forwarding the entire `*Key` parameter surface through every builder constructor was a worse trade-off than the chain it replaced. Exposing the methods on the serializable extensions instead is symmetric across all three serializables, keeps configuration where it belongs (next to the query definition), and leaves builder field types untouched.

The issue body on GitHub has been updated to reflect this revised approach.

## Steps completed

1. **`mutate` on `MutationSerializableExtension`** — replaces `mutation.mutationKey.mutate(...)` with `mutation.mutate(...)`. `MutationKey.mutate` removed.
2. **`query` / `infiniteQuery` / `definition` on the other extensions** — replaces the corresponding `*Key` chains. The `*Key.query()` / `*Key.definition()` methods remain as the implementation backing the extensions.
3. **Migration** — every `mutationKey.mutate(...)`, `.queryKey.query(...)`, `.infiniteQueryKey.query(...)`, `.mutationKey.definition(...)` user-style call site in `test/` and `example/` migrated. Internal `*Key` tests keep using local key vars (they exercise the implementation, not the user surface).
4. **Docs** — README, `docs/architecture.md`, CHANGELOG `[Unreleased]` (with before/after migration snippets), example/main.dart, and class-level dartdoc snippets all reflect the new surface.

## File change table

| Path | What changed |
|---|---|
| `lib/src/models/serializable.dart` | +4 extension methods (`query`, `infiniteQuery`, `definition`, `mutate`) with full dartdoc + See also cross-refs; refreshed class-level usage examples |
| `lib/src/models/mutation_key.dart` | Removed `MutationKey.mutate` (was a thin one-shot delegate); state inspection getters retained |
| `test/src/models/{mutation,query,infinite_query}_key_test.dart` | New test groups covering each convenience method (resolution + parameter forwarding); migrated user-style chains |
| `test/src/integration_test.dart` | Migrated `.mutationKey.mutate`, `.queryKey.query` chains |
| `example/main.dart` | Migrated all `*Key.*` chains to the new shape |
| `README.md`, `docs/architecture.md`, `CHANGELOG.md` | Reflect the new surface; CHANGELOG documents breaking removal of `MutationKey.mutate` with migration snippet |

## Test coverage

- Each new extension method has a focused test group covering resolution + at least one forwarded parameter (representative coverage; the type system catches param-rename drift on these thin forwarders).
- Full suite: 152 tests pass; `dart analyze` reports `No issues found!`.

## Test plan

- [ ] `dart analyze` reports `No issues found!`
- [ ] `flutter test` — all 152 tests pass
- [ ] `example/main.dart` compiles
- [ ] CHANGELOG migration snippets are accurate (try a search-and-replace in a downstream consumer)
- [ ] Verify `mutation.mutationKey.<inspection getter>` paths still work (`exists`, `isPending`, `error`, `isMutating`, `isRefetching`)
